### PR TITLE
37/audio files

### DIFF
--- a/src/items/FileAudio.d.ts
+++ b/src/items/FileAudio.d.ts
@@ -4,4 +4,4 @@ interface FileAudioProps {
   type: string;
 }
 
-declare const FileVideo: React.FC<FileAudioProps>;
+declare const FileAudio: React.FC<FileAudioProps>;

--- a/src/items/FileAudio.d.ts
+++ b/src/items/FileAudio.d.ts
@@ -1,0 +1,7 @@
+interface FileAudioProps {
+  id: string;
+  url: string;
+  type: string;
+}
+
+declare const FileVideo: React.FC<FileAudioProps>;

--- a/src/items/FileAudio.js
+++ b/src/items/FileAudio.js
@@ -7,7 +7,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const FileVideo = ({ id, url, type }) => {
+const FileAudio = ({ id, url, type }) => {
   const classes = useStyles();
   return (
     <audio className={classes.audio} id={id} controls>
@@ -16,4 +16,4 @@ const FileVideo = ({ id, url, type }) => {
   );
 };
 
-export default FileVideo;
+export default FileAudio;

--- a/src/items/FileAudio.js
+++ b/src/items/FileAudio.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+  audio: {
+    maxWidth: '100%',
+  },
+}));
+
+const FileVideo = ({ id, url, type }) => {
+  const classes = useStyles();
+  return (
+    <audio className={classes.audio} id={id} controls>
+      <source src={url} type={type} />
+    </audio>
+  );
+};
+
+export default FileVideo;

--- a/src/items/FileItem.js
+++ b/src/items/FileItem.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Alert from '@material-ui/lab/Alert';
 import { MIME_TYPES, UNEXPECTED_ERROR_MESSAGE } from '../constants';
 import FileImage from './FileImage';
+import FileAudio from './FileAudio';
 import FileVideo from './FileVideo';
 import FilePdf from './FilePdf';
 import { getFileExtra } from '../utils/itemExtra';
@@ -49,6 +50,8 @@ const FileItem = ({
   let component;
   if (MIME_TYPES.IMAGE.includes(mimetype)) {
     component = <FileImage id={id} url={url} alt={name} />;
+  } else if (MIME_TYPES.AUDIO.includes(mimetype)) {
+    component = <FileAudio id={id} url={url} type={mimetype} />;
   } else if (MIME_TYPES.VIDEO.includes(mimetype)) {
     component = <FileVideo id={id} url={url} type={mimetype} />;
   } else if (MIME_TYPES.PDF.includes(mimetype)) {

--- a/src/items/S3FileItem.js
+++ b/src/items/S3FileItem.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Alert from '@material-ui/lab/Alert';
 import { MIME_TYPES, UNEXPECTED_ERROR_MESSAGE } from '../constants';
+import FileAudio from './FileAudio';
 import FileImage from './FileImage';
 import FileVideo from './FileVideo';
 import FilePdf from './FilePdf';
@@ -51,6 +52,10 @@ const S3FileItem = ({
   let component;
   if (MIME_TYPES.IMAGE.includes(contenttype)) {
     component = <FileImage id={id} url={url} alt={name} />;
+  }
+
+  if (MIME_TYPES.AUDIO.includes(contenttype)) {
+    component = <FileAudio id={id} url={url} type={contenttype} />;
   }
 
   if (MIME_TYPES.VIDEO.includes(contenttype)) {


### PR DESCRIPTION
This PR add the possibility to use audio files in Graasp. This works on Compose & Perform.

close #37 & [compose#182](https://github.com/graasp/graasp-compose/issues/182) & [graasp-feedback#1](https://github.com/graasp/graasp-feedback/issues/1)

Graasp-Compose view :
![image](https://user-images.githubusercontent.com/44172411/129712326-49f566bb-0420-4bc8-a85d-cf4be1d52d77.png)

Graasp-Perform view :
![image](https://user-images.githubusercontent.com/44172411/129715385-efbc22ea-857c-426e-a509-1b9a2e5c056c.png)


