### PR TITLE
feat: add more headings and fonts for text editor

### DIFF
--- a/src/TextEditor/TextEditor.tsx
+++ b/src/TextEditor/TextEditor.tsx
@@ -3,7 +3,11 @@ import { makeStyles } from '@material-ui/core/styles';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import SaveButton from '../SaveButton';
-import { TEXT_EDITOR_MIN_HEIGHT, TEXT_EDITOR_TOOLBAR } from '../constants';
+import {
+  TEXT_EDITOR_MAX_HEIGHT,
+  TEXT_EDITOR_MIN_HEIGHT,
+  TEXT_EDITOR_TOOLBAR,
+} from '../constants';
 
 // formula dependencies
 import katex from 'katex';
@@ -21,6 +25,7 @@ interface TextEditorProps {
   saveButtonId?: string;
   saveButtonText?: string;
   showSaveButton?: boolean;
+  maxHeight?: string | number;
 }
 
 const TextEditor: FC<TextEditorProps> = ({
@@ -33,6 +38,7 @@ const TextEditor: FC<TextEditorProps> = ({
   showSaveButton = true,
   edit = false,
   placeholderText = 'Write something...',
+  maxHeight,
 }) => {
   // keep current content
   const [content, setContent] = useState(initialValue ?? '');
@@ -41,6 +47,10 @@ const TextEditor: FC<TextEditorProps> = ({
       '& .ql-editor': {
         // adapt height if read only
         minHeight: !edit ? 0 : TEXT_EDITOR_MIN_HEIGHT,
+        // necessary styles to avoid window scrolling top on paste
+        // set a max height only on edition
+        maxHeight: edit ? maxHeight ?? TEXT_EDITOR_MAX_HEIGHT : '100%',
+        overflow: 'auto',
       },
       '& .ql-container': {
         border: !edit ? 'none' : undefined,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const TEXT_EDITOR_TOOLBAR = [
   [{ list: 'ordered' }, { list: 'bullet' }, 'code-block', 'link', 'formula'],
 ];
 export const TEXT_EDITOR_MIN_HEIGHT = 200;
+export const TEXT_EDITOR_MAX_HEIGHT = 400;
 export const APP_ITEM_WIDTH = '100%';
 export const APP_ITEM_FRAME_BORDER = 0;
 export const UNEXPECTED_ERROR_MESSAGE = 'An unexpected error occurred';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,8 @@ export const MIME_TYPES = {
 
 export const TEXT_EDITOR_TOOLBAR = [
   [
-    { header: [] },
+    { header: [1, 2, 3, 4, 5, 6, false] },
+    { font: [] },
     'bold',
     'italic',
     'underline',
@@ -70,3 +71,4 @@ export const THUMBNAIL_SIZES = {
 export const DEFAULT_THUMBNAIL_SIZE = THUMBNAIL_SIZES.SMALL;
 
 export const FLAG_LIST_MAX_HEIGHT = 250;
+export const DEFAULT_PERMISSION = 'read';

--- a/src/items/DocumentItem.tsx
+++ b/src/items/DocumentItem.tsx
@@ -11,6 +11,7 @@ interface DocumentItemProps {
   saveButtonId?: string;
   saveButtonText?: string;
   onSave: () => void;
+  maxHeight?: string | number;
 }
 
 const DocumentItem: FC<DocumentItemProps> = ({
@@ -20,6 +21,7 @@ const DocumentItem: FC<DocumentItemProps> = ({
   onSave,
   saveButtonId,
   saveButtonText,
+  maxHeight,
 }) => (
   <TextEditor
     id={id}
@@ -28,6 +30,7 @@ const DocumentItem: FC<DocumentItemProps> = ({
     onSave={onSave}
     saveButtonId={saveButtonId}
     saveButtonText={saveButtonText}
+    maxHeight={maxHeight}
   />
 );
 


### PR DESCRIPTION
This PR added more headings, and fonts for the text editor (request from Gilles).

close #78 
<img width="875" alt="Screenshot 2022-02-16 at 16 19 36" src="https://user-images.githubusercontent.com/11229627/154296248-949f5858-ddeb-4fbc-bbdc-8b6dbeff0644.png">
<img width="889" alt="Screenshot 2022-02-16 at 16 19 30" src="https://user-images.githubusercontent.com/11229627/154296261-49b1035c-285d-48bc-826c-23a70937d543.png">

close https://github.com/graasp/graasp-ui/issues/77