### PR TITLE
fix: revert to default iframe

### DIFF
--- a/src/items/H5PItem.tsx
+++ b/src/items/H5PItem.tsx
@@ -93,7 +93,7 @@ const H5PItem: FC<H5PItemProps> = ({
       src={integrationUrl.href}
       scrolling={'no'}
       frameBorder={0}
-      sandbox='allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts'
+      sandbox='allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-same-origin'
       style={{ width: '100%', border: 'none', display: 'block' }}
     ></iframe>
   );

--- a/src/items/H5PItem.tsx
+++ b/src/items/H5PItem.tsx
@@ -93,7 +93,6 @@ const H5PItem: FC<H5PItemProps> = ({
       src={integrationUrl.href}
       scrolling={'no'}
       frameBorder={0}
-      sandbox='allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-same-origin'
       style={{ width: '100%', border: 'none', display: 'block' }}
     ></iframe>
   );


### PR DESCRIPTION
H5P cannot be displayed anymore since last update of H5P iframes (the origin of the iframe is now null because of the sandbox)