### PR TITLE
feat: support wav as audio format

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ export const DRAWER_HEADER_HEIGHT = 55;
 export const LOADING_TEXT = '…';
 
 export const MIME_TYPES = {
-  IMAGE: ['image/png', 'image/jpg', 'image/gif', 'image/jpeg'],
+  IMAGE: ['image/png', 'image/jpg', 'image/gif', 'image/jpeg', 'image/svg+xml'],
   VIDEO: [
     'video/mp4',
     'video/x-m4v',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const MIME_TYPES = {
     'video/quicktime',
     'video/webm',
   ],
-  AUDIO: ['audio/mpeg', 'audio/mp3'],
+  AUDIO: ['audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav'],
   PDF: ['application/pdf'],
   ZIP: ['application/zip'],
 };

--- a/src/items/FileAudio.stories.tsx
+++ b/src/items/FileAudio.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import React from 'react';
+
+import { MIME_TYPES } from '../constants';
+import { TABLE_CATEGORIES } from '../utils/storybook';
+import FileAudio from './FileAudio';
+
+export default {
+  title: 'Items/FileAudio',
+  component: FileAudio,
+
+  argTypes: {
+    sx: {
+      table: {
+        category: TABLE_CATEGORIES.MUI,
+      },
+    },
+  },
+} as ComponentMeta<typeof FileAudio>;
+
+const Template: ComponentStory<typeof FileAudio> = (args) => (
+  <FileAudio {...args} />
+);
+
+export const MP3Audio = Template.bind({});
+MP3Audio.args = {
+  id: 'some-audio-file-id',
+  url: 'https://upload.wikimedia.org/wikipedia/commons/e/e1/Heart_Monitor_Beep--freesound.org.mp3',
+  type: MIME_TYPES.AUDIO[2], // should be mp3 format
+};
+MP3Audio.storyName = 'MP3 Audio';
+
+export const WAVAudio = Template.bind({});
+WAVAudio.args = {
+  id: 'some-audio-file-id',
+  url: 'https://upload.wikimedia.org/wikipedia/commons/b/be/Bigroom_kick.wav',
+  type: MIME_TYPES.AUDIO[3], // should be wav format
+};

--- a/src/items/FileAudio.tsx
+++ b/src/items/FileAudio.tsx
@@ -2,12 +2,12 @@ import { SxProps, styled } from '@mui/material';
 
 import React, { FC } from 'react';
 
-interface FileAudioProps {
+type FileAudioProps = {
   id?: string;
   url?: string;
   type: string;
   sx?: SxProps;
-}
+};
 
 const FileAudio: FC<FileAudioProps> = ({ id, url, type, sx }) => {
   const StyledAudio = styled('audio')({

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -60,7 +60,9 @@ Image.args = {
 export const ImageSVG = Template.bind({});
 ImageSVG.loaders = [
   async () => ({
-    content: await fetch('https://upload.wikimedia.org/wikipedia/commons/b/bd/Test.svg').then((r) => r.blob()),
+    content: await fetch(
+      'https://upload.wikimedia.org/wikipedia/commons/b/bd/Test.svg',
+    ).then((r) => r.blob()),
   }),
 ];
 ImageSVG.args = {
@@ -73,6 +75,36 @@ ImageSVG.args = {
         mimetype: MIME_TYPES.IMAGE[4], // Should be image/svg+xml
         name: 'original file name',
         size: 2600,
+      },
+    },
+    type: 'file',
+    description: '',
+    path: 'item-path',
+    settings: {},
+    creator: 'creator',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+  }),
+};
+
+export const WAVAudio = Template.bind({});
+WAVAudio.loaders = [
+  async () => ({
+    content: await fetch(
+      'https://upload.wikimedia.org/wikipedia/commons/8/8f/Bass_loop_2_%28Carrai_Pass%29.wav',
+    ).then((r) => r.blob()),
+  }),
+];
+WAVAudio.args = {
+  item: convertJs<LocalFileItemType>({
+    id: 'my-id',
+    name: 'my item name',
+    extra: {
+      [ItemType.LOCAL_FILE]: {
+        path: 'https://upload.wikimedia.org/wikipedia/commons/8/8f/Bass_loop_2_%28Carrai_Pass%29.wav',
+        mimetype: MIME_TYPES.AUDIO[3], // Should be audio/wav
+        name: 'original file name',
+        size: 10000000,
       },
     },
     type: 'file',

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -56,3 +56,31 @@ Image.args = {
     updatedAt: 'updatedAt',
   }),
 };
+
+export const ImageSVG = Template.bind({});
+ImageSVG.loaders = [
+  async () => ({
+    content: await fetch('https://upload.wikimedia.org/wikipedia/commons/b/bd/Test.svg').then((r) => r.blob()),
+  }),
+];
+ImageSVG.args = {
+  item: convertJs<LocalFileItemType>({
+    id: 'my-id',
+    name: 'my item name',
+    extra: {
+      [ItemType.LOCAL_FILE]: {
+        path: 'https://upload.wikimedia.org/wikipedia/commons/b/bd/Test.svg',
+        mimetype: MIME_TYPES.IMAGE[4], // Should be image/svg+xml
+        name: 'original file name',
+        size: 2600,
+      },
+    },
+    type: 'file',
+    description: '',
+    path: 'item-path',
+    settings: {},
+    creator: 'creator',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+  }),
+};


### PR DESCRIPTION
Currently audio files in WAV format are shown as the default file (download button)  while they could be played in the browser.

Adding the MIME type will allow the files to be displayed as an audio file and played directly.


closes #255