### PR TITLE
257 use buttontypeenum

### DIFF
--- a/src/buttons/DeleteButton/DeleteButton.tsx
+++ b/src/buttons/DeleteButton/DeleteButton.tsx
@@ -35,7 +35,7 @@ const DeleteButton: FC<Props> = ({
           {text}
         </MenuItem>
       );
-    case ButtonTypeEnum.ICON:
+    case ButtonTypeEnum.ICON_BUTTON:
     default:
       return (
         <Tooltip title={text}>

--- a/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
+++ b/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
@@ -45,3 +45,6 @@ Default.args = {};
 
 export const IsFavorite = Template.bind({});
 IsFavorite.args = { isFavorite: true };
+
+export const MenuItem = Template.bind({});
+MenuItem.args = { text: 'Add to Favorites', type: ButtonTypeEnum.MENU_ITEM };

--- a/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
+++ b/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
+import { ButtonTypeEnum } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import FavoriteButton from './FavoriteButton';
 

--- a/src/buttons/FavoriteButton/FavoriteButton.tsx
+++ b/src/buttons/FavoriteButton/FavoriteButton.tsx
@@ -69,7 +69,7 @@ const FavoriteButton: FC<FavoriteButtonProps> = ({
           {text}
         </MenuItem>
       );
-    case ButtonTypeEnum.ICON:
+    case ButtonTypeEnum.ICON_BUTTON:
     default:
       return (
         <Tooltip title={tooltipText}>

--- a/src/buttons/FavoriteButton/FavoriteButton.tsx
+++ b/src/buttons/FavoriteButton/FavoriteButton.tsx
@@ -42,7 +42,7 @@ const FavoriteButton: FC<FavoriteButtonProps> = ({
   handleFavorite,
   handleUnfavorite,
   isFavorite = false,
-  size = 'large',
+  size = 'medium',
   sx,
   text,
   tooltip,

--- a/src/buttons/MoveButton/MoveButton.stories.tsx
+++ b/src/buttons/MoveButton/MoveButton.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import { BUTTON_TYPES } from '../../constants';
+import { ButtonTypeEnum } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import MoveButton from './MoveButton';
 
@@ -31,10 +31,10 @@ const Template: ComponentStory<typeof MoveButton> = (args) => (
 
 export const MenuItem = Template.bind({});
 MenuItem.args = {
-  type: BUTTON_TYPES.MENU_ITEM,
+  type: ButtonTypeEnum.MENU_ITEM,
 };
 
 export const Icon = Template.bind({});
 Icon.args = {
-  type: BUTTON_TYPES.ICON_BUTTON,
+  type: ButtonTypeEnum.ICON_BUTTON,
 };

--- a/src/buttons/MoveButton/MoveButton.tsx
+++ b/src/buttons/MoveButton/MoveButton.tsx
@@ -6,8 +6,7 @@ import Tooltip from '@mui/material/Tooltip';
 
 import React, { FC } from 'react';
 
-import { BUTTON_TYPES } from '../../constants';
-import { ButtonType } from '../../types';
+import { ButtonType, ButtonTypeEnum } from '../../types';
 
 type MoveButtonProps = {
   color?: IconButtonProps['color'];
@@ -28,10 +27,10 @@ const MoveButton: FC<MoveButtonProps> = ({
   onClick,
   size,
   text = 'Move',
-  type = BUTTON_TYPES.ICON_BUTTON,
+  type = ButtonTypeEnum.ICON_BUTTON,
 }) => {
   switch (type) {
-    case BUTTON_TYPES.MENU_ITEM:
+    case ButtonTypeEnum.MENU_ITEM:
       return (
         <MenuItem key={text} onClick={onClick} className={menuItemClassName}>
           <ListItemIcon>
@@ -40,7 +39,7 @@ const MoveButton: FC<MoveButtonProps> = ({
           {text}
         </MenuItem>
       );
-    case BUTTON_TYPES.ICON_BUTTON:
+    case ButtonTypeEnum.ICON_BUTTON:
     default:
       return (
         <Tooltip title={text}>

--- a/src/buttons/PinButton/PinButton.stories.tsx
+++ b/src/buttons/PinButton/PinButton.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import { BUTTON_TYPES } from '../../constants';
+import { ButtonTypeEnum } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import PinButton from './PinButton';
 
@@ -36,10 +36,10 @@ IsPinned.args = {
 
 export const Icon = Template.bind({});
 Icon.args = {
-  type: BUTTON_TYPES.ICON_BUTTON,
+  type: ButtonTypeEnum.ICON_BUTTON,
 };
 
 export const MenuItem = Template.bind({});
 MenuItem.args = {
-  type: BUTTON_TYPES.MENU_ITEM,
+  type: ButtonTypeEnum.MENU_ITEM,
 };

--- a/src/buttons/PinButton/PinButton.tsx
+++ b/src/buttons/PinButton/PinButton.tsx
@@ -7,8 +7,7 @@ import Tooltip from '@mui/material/Tooltip';
 
 import React, { FC } from 'react';
 
-import { BUTTON_TYPES } from '../../constants';
-import { ButtonType } from '../../types';
+import { ButtonType, ButtonTypeEnum } from '../../types';
 
 export type PinButtonProps = {
   color?: IconButtonProps['color'];
@@ -37,7 +36,7 @@ const PinButton: FC<PinButtonProps> = ({
   const text = isPinned ? unPinText : pinText;
 
   switch (type) {
-    case BUTTON_TYPES.MENU_ITEM:
+    case ButtonTypeEnum.MENU_ITEM:
       return (
         <MenuItem key={text} onClick={onClick} className={menuItemClassName}>
           <ListItemIcon>{icon}</ListItemIcon>
@@ -45,7 +44,7 @@ const PinButton: FC<PinButtonProps> = ({
         </MenuItem>
       );
     default:
-    case BUTTON_TYPES.ICON_BUTTON:
+    case ButtonTypeEnum.ICON_BUTTON:
       return (
         <Tooltip title={text}>
           <span>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,9 +103,4 @@ export const GRAASP_ASSETS_PROTOCOL = 'https://';
 
 export const SCREEN_MAX_HEIGHT = window.innerHeight * 0.8;
 
-export const BUTTON_TYPES = {
-  MENU_ITEM: 'menuItem',
-  ICON_BUTTON: 'iconButton',
-};
-
 export const FAVORITE_COLOR = '#ffc107';

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,8 @@ export const ImmutableItemLoginFactory = Record({
 });
 
 export enum ButtonTypeEnum {
-  ICON = 'icon',
+  ICON_BUTTON = 'icon',
   MENU_ITEM = 'menuItem',
 }
-export type ButtonType = 'icon' | 'menuItem' | ButtonTypeEnum | string;
+
+export type ButtonType = `${ButtonTypeEnum}`;


### PR DESCRIPTION
This PR uniformises the use of the `ButtonTypeEnum` and removes the `BUTTON_TYPE` object.

closes #257 