### PR TITLE
fix: set default skeleton variant to circular for Avatar

### DIFF
--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -44,7 +44,7 @@ const Avatar: FC<AvatarProps> = ({
   blob: thumbnailBlob,
   maxWidth = '100%',
   maxHeight = '100%',
-  variant,
+  variant = 'circular',
   component = 'img',
   isLoading,
   className,

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -32,7 +32,7 @@ type CardProps = {
    */
   image?: string;
   ItemMenu?: ReactElement;
-  NameWrapper?: FC;
+  NameWrapper?: ({ children }: { children: JSX.Element }) => JSX.Element;
   sx?: SxProps;
   /**
    * thumbnail component, override image

--- a/src/Card/CardHeader.tsx
+++ b/src/Card/CardHeader.tsx
@@ -7,7 +7,7 @@ type CardHeaderProps = {
   name: string;
   creator?: string;
   ItemMenu?: ReactElement;
-  NameWrapper?: FC;
+  NameWrapper?: ({ children }: { children: JSX.Element }) => JSX.Element;
 };
 
 const CustomCardHeader: FC<CardHeaderProps> = ({

--- a/src/items/ItemSkeleton/ItemSkeleton.tsx
+++ b/src/items/ItemSkeleton/ItemSkeleton.tsx
@@ -54,7 +54,7 @@ const ItemSkeleton: React.FC<ItemSkeletonProps> = ({
         ItemType.S3_FILE,
         ItemType.LINK,
         ItemType.APP,
-      ] as string[]
+      ] as `${ItemType}`[]
     ).includes(itemType): {
       return (
         <Skeleton

--- a/src/items/ItemSkeleton/ItemSkeleton.tsx
+++ b/src/items/ItemSkeleton/ItemSkeleton.tsx
@@ -16,7 +16,7 @@ export interface ItemSkeletonProps {
    */
   isChildren: boolean;
   isCollapsible?: boolean;
-  itemType: ItemType;
+  itemType: `${ItemType}` | ItemType;
   screenMaxHeight?: number;
 }
 
@@ -48,12 +48,14 @@ const ItemSkeleton: React.FC<ItemSkeletonProps> = ({
         />
       );
     }
-    case [
-      ItemType.LOCAL_FILE,
-      ItemType.S3_FILE,
-      ItemType.LINK,
-      ItemType.APP,
-    ].includes(itemType): {
+    case (
+      [
+        ItemType.LOCAL_FILE,
+        ItemType.S3_FILE,
+        ItemType.LINK,
+        ItemType.APP,
+      ] as string[]
+    ).includes(itemType): {
       return (
         <Skeleton
           variant='rectangular'


### PR DESCRIPTION
This PR updates the default skeleton shape value for the `Avatar` component.

closes #263 