### PR TITLE
fix: add key to list element in platform switch

### DIFF
--- a/src/PlatformSwitch/PlatformSwitch.tsx
+++ b/src/PlatformSwitch/PlatformSwitch.tsx
@@ -145,6 +145,7 @@ export const PlatformSwitch: FC<PlatformSwitchProps> = ({
 
   const buttons = Object.values(Platform).map((platform, index, platforms) => (
     <PlatformButton
+      key={platform}
       // the last icon does not need margin at the end
       sx={{ mr: index === platforms.length - 1 ? 0 : spacing }}
       platform={platform}


### PR DESCRIPTION
This PR should fix the react error about missing key in list.

closes #265
