### PR TITLE
fix: use MimeTypes and ThumbnailSize from sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "storybook:build": "build-storybook"
   },
   "dependencies": {
-    "@graasp/sdk": "0.8.0",
+    "@graasp/sdk": "0.8.1",
     "clsx": "1.1.1",
     "http-status-codes": "2.2.0",
     "immutable": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
     "post-commit": "git status",
-    "pre-commit": "yarn prettier:check && yarn lint",
+    "pre-commit": "yarn check",
     "storybook": "start-storybook -p 6006",
     "storybook:test": "test-storybook --coverage",
     "storybook:build": "build-storybook"
   },
   "dependencies": {
-    "@graasp/sdk": "0.6.0",
+    "@graasp/sdk": "0.8.0",
     "clsx": "1.1.1",
     "http-status-codes": "2.2.0",
     "immutable": "4.2.4",

--- a/src/Thumbnail/Thumbnail.tsx
+++ b/src/Thumbnail/Thumbnail.tsx
@@ -4,9 +4,11 @@ import Skeleton from '@mui/material/Skeleton';
 import React, { FC, useEffect, useState } from 'react';
 import { QueryObserverResult } from 'react-query';
 
+import { ThumbnailSizeVariant } from '@graasp/sdk/frontend';
+
 import { StyledImage } from '../StyledComponents/StyledBaseComponents';
 import { DEFAULT_THUMBNAIL_SIZE } from '../constants';
-import { ThumbnailSizeVariant, Variant } from '../types';
+import { Variant } from '../types';
 import { getItemImage } from '../utils/image';
 
 type ThumbnailProps = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,23 +5,6 @@ export const DEFAULT_DIRECTION = 'ltr';
 export const DRAWER_HEADER_HEIGHT = 55;
 export const LOADING_TEXT = '…';
 
-/**
- * @deprecated use from graasp/sdk
- */
-export const MIME_TYPES = {
-  IMAGE: ['image/png', 'image/jpg', 'image/gif', 'image/jpeg', 'image/svg+xml'],
-  VIDEO: [
-    'video/mp4',
-    'video/x-m4v',
-    'video/ogg',
-    'video/quicktime',
-    'video/webm',
-  ],
-  AUDIO: ['audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav'],
-  PDF: ['application/pdf'],
-  ZIP: ['application/zip'],
-};
-
 export const TEXT_EDITOR_TOOLBAR = [
   [{ header: [1, 2, 3, 4, 5, 6, false] }],
   [{ font: [] }],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { ThumbnailSize } from '@graasp/sdk/frontend';
+import { ThumbnailSize } from '@graasp/sdk';
 
 export const DRAWER_WIDTH = 240;
 export const DEFAULT_DIRECTION = 'ltr';
@@ -62,7 +62,7 @@ export const FORBIDDEN_TEXT = 'You cannot access this item';
 export const ITEM_MAX_HEIGHT = '70vh';
 export const DEFAULT_CARD_HEIGHT = 130;
 
-export const DEFAULT_THUMBNAIL_SIZE = ThumbnailSize.SMALL;
+export const DEFAULT_THUMBNAIL_SIZE = ThumbnailSize.Small;
 
 export const FLAG_LIST_MAX_HEIGHT = 250;
 export const DEFAULT_PERMISSION = 'read';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { ThumbnailSize } from '@graasp/sdk/frontend';
+
 export const DRAWER_WIDTH = 240;
 export const DEFAULT_DIRECTION = 'ltr';
 export const DRAWER_HEADER_HEIGHT = 55;
@@ -77,17 +79,7 @@ export const FORBIDDEN_TEXT = 'You cannot access this item';
 export const ITEM_MAX_HEIGHT = '70vh';
 export const DEFAULT_CARD_HEIGHT = 130;
 
-/**
- * @deprecated
- */
-export const THUMBNAIL_SIZES = {
-  SMALL: 'small',
-  MEDIUM: 'medium',
-  LARGE: 'large',
-  ORIGINAL: 'original',
-};
-
-export const DEFAULT_THUMBNAIL_SIZE = THUMBNAIL_SIZES.SMALL;
+export const DEFAULT_THUMBNAIL_SIZE = ThumbnailSize.SMALL;
 
 export const FLAG_LIST_MAX_HEIGHT = 250;
 export const DEFAULT_PERMISSION = 'read';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,9 @@ export const DEFAULT_DIRECTION = 'ltr';
 export const DRAWER_HEADER_HEIGHT = 55;
 export const LOADING_TEXT = '…';
 
+/**
+ * @deprecated use from graasp/sdk
+ */
 export const MIME_TYPES = {
   IMAGE: ['image/png', 'image/jpg', 'image/gif', 'image/jpeg', 'image/svg+xml'],
   VIDEO: [
@@ -74,6 +77,9 @@ export const FORBIDDEN_TEXT = 'You cannot access this item';
 export const ITEM_MAX_HEIGHT = '70vh';
 export const DEFAULT_CARD_HEIGHT = 130;
 
+/**
+ * @deprecated
+ */
 export const THUMBNAIL_SIZES = {
   SMALL: 'small',
   MEDIUM: 'medium',

--- a/src/icons/ItemIcon.stories.tsx
+++ b/src/icons/ItemIcon.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import { ItemType, MIME_TYPES } from '@graasp/sdk';
+import { ItemType, MimeTypes } from '@graasp/sdk';
 
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import ItemIcon from './ItemIcon';
@@ -46,7 +46,7 @@ Image.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.IMAGE.JPEG,
+      mimetype: MimeTypes.Image.JPEG,
     },
   },
 };
@@ -57,7 +57,7 @@ Video.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.VIDEO.MP4,
+      mimetype: MimeTypes.Video.MP4,
     },
   },
 };
@@ -67,7 +67,7 @@ Audio.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.AUDIO.MP3,
+      mimetype: MimeTypes.Audio.MP3,
     },
   },
 };
@@ -78,7 +78,7 @@ PDF.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.PDF,
+      mimetype: MimeTypes.PDF,
     },
   },
 };
@@ -89,7 +89,7 @@ ZIP.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.ZIP,
+      mimetype: MimeTypes.ZIP,
     },
   },
 };

--- a/src/icons/ItemIcon.stories.tsx
+++ b/src/icons/ItemIcon.stories.tsx
@@ -2,9 +2,8 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import { ItemType } from '@graasp/sdk';
+import { ItemType, MIME_TYPES } from '@graasp/sdk';
 
-import { MIME_TYPES } from '../constants';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import ItemIcon from './ItemIcon';
 
@@ -47,7 +46,7 @@ Image.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.IMAGE[0],
+      mimetype: MIME_TYPES.IMAGE.JPEG,
     },
   },
 };
@@ -58,7 +57,7 @@ Video.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.VIDEO[0],
+      mimetype: MIME_TYPES.VIDEO.MP4,
     },
   },
 };
@@ -68,7 +67,7 @@ Audio.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.AUDIO[0],
+      mimetype: MIME_TYPES.AUDIO.MP3,
     },
   },
 };
@@ -79,7 +78,7 @@ PDF.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.PDF[0],
+      mimetype: MIME_TYPES.PDF,
     },
   },
 };
@@ -90,7 +89,7 @@ ZIP.args = {
   color: 'black',
   extra: {
     [ItemType.S3_FILE]: {
-      mimetype: MIME_TYPES.ZIP[0],
+      mimetype: MIME_TYPES.ZIP,
     },
   },
 };

--- a/src/icons/ItemIcon.tsx
+++ b/src/icons/ItemIcon.tsx
@@ -18,7 +18,7 @@ import React, { FC } from 'react';
 import {
   ItemType,
   LocalFileItemExtra,
-  MIME_TYPES,
+  MimeTypes,
   S3FileItemExtra,
   UnknownExtra,
   getFileExtra,
@@ -94,23 +94,23 @@ const ItemIcon: FC<ItemIconProps> = ({
     case ItemType.LOCAL_FILE:
     case ItemType.S3_FILE: {
       if (mimetype) {
-        if (MIME_TYPES.isImage(mimetype)) {
+        if (MimeTypes.isImage(mimetype)) {
           Icon = ImageIcon;
           break;
         }
-        if (MIME_TYPES.isVideo(mimetype)) {
+        if (MimeTypes.isVideo(mimetype)) {
           Icon = MovieIcon;
           break;
         }
-        if (MIME_TYPES.isAudio(mimetype)) {
+        if (MimeTypes.isAudio(mimetype)) {
           Icon = MusicNoteIcon;
           break;
         }
-        if (MIME_TYPES.isPdf(mimetype)) {
+        if (MimeTypes.isPdf(mimetype)) {
           Icon = PictureAsPdfIcon;
           break;
         }
-        if (MIME_TYPES.isZip(mimetype)) {
+        if (MimeTypes.isZip(mimetype)) {
           Icon = FolderZipIcon;
           break;
         }

--- a/src/icons/ItemIcon.tsx
+++ b/src/icons/ItemIcon.tsx
@@ -18,6 +18,7 @@ import React, { FC } from 'react';
 import {
   ItemType,
   LocalFileItemExtra,
+  MIME_TYPES,
   S3FileItemExtra,
   UnknownExtra,
   getFileExtra,
@@ -26,7 +27,7 @@ import {
 import { ItemRecord } from '@graasp/sdk/frontend';
 
 import { StyledImage } from '../StyledComponents/StyledBaseComponents';
-import { ITEM_ICON_MAX_SIZE, MIME_TYPES } from '../constants';
+import { ITEM_ICON_MAX_SIZE } from '../constants';
 
 export interface ItemIconProps {
   alt: string;
@@ -93,23 +94,23 @@ const ItemIcon: FC<ItemIconProps> = ({
     case ItemType.LOCAL_FILE:
     case ItemType.S3_FILE: {
       if (mimetype) {
-        if (MIME_TYPES.IMAGE.includes(mimetype)) {
+        if (MIME_TYPES.isImage(mimetype)) {
           Icon = ImageIcon;
           break;
         }
-        if (MIME_TYPES.VIDEO.includes(mimetype)) {
+        if (MIME_TYPES.isVideo(mimetype)) {
           Icon = MovieIcon;
           break;
         }
-        if (MIME_TYPES.AUDIO.includes(mimetype)) {
+        if (MIME_TYPES.isAudio(mimetype)) {
           Icon = MusicNoteIcon;
           break;
         }
-        if (MIME_TYPES.PDF.includes(mimetype)) {
+        if (MIME_TYPES.isPdf(mimetype)) {
           Icon = PictureAsPdfIcon;
           break;
         }
-        if (MIME_TYPES.ZIP.includes(mimetype)) {
+        if (MIME_TYPES.isZip(mimetype)) {
           Icon = FolderZipIcon;
           break;
         }

--- a/src/items/FileAudio.stories.tsx
+++ b/src/items/FileAudio.stories.tsx
@@ -2,7 +2,8 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import { MIME_TYPES } from '../constants';
+import { MIME_TYPES } from '@graasp/sdk';
+
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import FileAudio from './FileAudio';
 
@@ -27,7 +28,7 @@ export const MP3Audio = Template.bind({});
 MP3Audio.args = {
   id: 'some-audio-file-id',
   url: 'https://upload.wikimedia.org/wikipedia/commons/e/e1/Heart_Monitor_Beep--freesound.org.mp3',
-  type: MIME_TYPES.AUDIO[2], // should be mp3 format
+  type: MIME_TYPES.AUDIO.MP3, // should be mp3 format
 };
 MP3Audio.storyName = 'MP3 Audio';
 
@@ -35,5 +36,5 @@ export const WAVAudio = Template.bind({});
 WAVAudio.args = {
   id: 'some-audio-file-id',
   url: 'https://upload.wikimedia.org/wikipedia/commons/b/be/Bigroom_kick.wav',
-  type: MIME_TYPES.AUDIO[3], // should be wav format
+  type: MIME_TYPES.AUDIO.WAV, // should be wav format
 };

--- a/src/items/FileAudio.stories.tsx
+++ b/src/items/FileAudio.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import { MIME_TYPES } from '@graasp/sdk';
+import { MimeTypes } from '@graasp/sdk';
 
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import FileAudio from './FileAudio';
@@ -28,7 +28,7 @@ export const MP3Audio = Template.bind({});
 MP3Audio.args = {
   id: 'some-audio-file-id',
   url: 'https://upload.wikimedia.org/wikipedia/commons/e/e1/Heart_Monitor_Beep--freesound.org.mp3',
-  type: MIME_TYPES.AUDIO.MP3, // should be mp3 format
+  type: MimeTypes.Audio.MP3, // should be mp3 format
 };
 MP3Audio.storyName = 'MP3 Audio';
 
@@ -36,5 +36,5 @@ export const WAVAudio = Template.bind({});
 WAVAudio.args = {
   id: 'some-audio-file-id',
   url: 'https://upload.wikimedia.org/wikipedia/commons/b/be/Bigroom_kick.wav',
-  type: MIME_TYPES.AUDIO.WAV, // should be wav format
+  type: MimeTypes.Audio.WAV, // should be wav format
 };

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -3,12 +3,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import {
-  ItemType,
-  LocalFileItemType,
-  MIME_TYPES,
-  convertJs,
-} from '@graasp/sdk';
+import { ItemType, LocalFileItemType, MimeTypes, convertJs } from '@graasp/sdk';
 
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import FileItem from './FileItem';
@@ -46,7 +41,7 @@ Image.args = {
     extra: {
       [ItemType.LOCAL_FILE]: {
         path: 'https://picsum.photos/100',
-        mimetype: MIME_TYPES.IMAGE.PNG,
+        mimetype: MimeTypes.Image.PNG,
         name: 'original file name',
         size: 2600,
       },
@@ -76,7 +71,7 @@ ImageSVG.args = {
     extra: {
       [ItemType.LOCAL_FILE]: {
         path: 'https://upload.wikimedia.org/wikipedia/commons/b/bd/Test.svg',
-        mimetype: MIME_TYPES.IMAGE.SVG, // Should be image/svg+xml
+        mimetype: MimeTypes.Image.SVG, // Should be image/svg+xml
         name: 'original file name',
         size: 2600,
       },
@@ -106,7 +101,7 @@ WAVAudio.args = {
     extra: {
       [ItemType.LOCAL_FILE]: {
         path: 'https://upload.wikimedia.org/wikipedia/commons/8/8f/Bass_loop_2_%28Carrai_Pass%29.wav',
-        mimetype: MIME_TYPES.AUDIO.WAV, // Should be audio/wav
+        mimetype: MimeTypes.Audio.WAV, // Should be audio/wav
         name: 'original file name',
         size: 10000000,
       },

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -3,9 +3,13 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import React from 'react';
 
-import { ItemType, LocalFileItemType, convertJs } from '@graasp/sdk';
+import {
+  ItemType,
+  LocalFileItemType,
+  MIME_TYPES,
+  convertJs,
+} from '@graasp/sdk';
 
-import { MIME_TYPES } from '../constants';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import FileItem from './FileItem';
 
@@ -42,7 +46,7 @@ Image.args = {
     extra: {
       [ItemType.LOCAL_FILE]: {
         path: 'https://picsum.photos/100',
-        mimetype: MIME_TYPES.IMAGE[0],
+        mimetype: MIME_TYPES.IMAGE.PNG,
         name: 'original file name',
         size: 2600,
       },
@@ -72,7 +76,7 @@ ImageSVG.args = {
     extra: {
       [ItemType.LOCAL_FILE]: {
         path: 'https://upload.wikimedia.org/wikipedia/commons/b/bd/Test.svg',
-        mimetype: MIME_TYPES.IMAGE[4], // Should be image/svg+xml
+        mimetype: MIME_TYPES.IMAGE.SVG, // Should be image/svg+xml
         name: 'original file name',
         size: 2600,
       },
@@ -102,7 +106,7 @@ WAVAudio.args = {
     extra: {
       [ItemType.LOCAL_FILE]: {
         path: 'https://upload.wikimedia.org/wikipedia/commons/8/8f/Bass_loop_2_%28Carrai_Pass%29.wav',
-        mimetype: MIME_TYPES.AUDIO[3], // Should be audio/wav
+        mimetype: MIME_TYPES.AUDIO.WAV, // Should be audio/wav
         name: 'original file name',
         size: 10000000,
       },

--- a/src/items/FileItem.tsx
+++ b/src/items/FileItem.tsx
@@ -6,6 +6,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import {
   LocalFileItemExtra,
+  MIME_TYPES,
   S3FileItemExtra,
   getFileExtra,
   getS3FileExtra,
@@ -16,11 +17,7 @@ import {
   S3FileItemTypeRecord,
 } from '@graasp/sdk/frontend';
 
-import {
-  MIME_TYPES,
-  SCREEN_MAX_HEIGHT,
-  UNEXPECTED_ERROR_MESSAGE,
-} from '../constants';
+import { SCREEN_MAX_HEIGHT, UNEXPECTED_ERROR_MESSAGE } from '../constants';
 import { ERRORS } from '../enums';
 import DownloadButtonFileItem from './DownloadButtonFileItem';
 import FileAudio from './FileAudio';
@@ -119,14 +116,14 @@ const FileItem: FC<FileItemProps> = ({
 
   let component;
   if (mimetype) {
-    if (MIME_TYPES.IMAGE.includes(mimetype)) {
+    if (MIME_TYPES.isImage(mimetype)) {
       component = <FileImage id={id} url={url} alt={name} sx={sx} />;
-    } else if (MIME_TYPES.AUDIO.includes(mimetype)) {
+    } else if (MIME_TYPES.isAudio(mimetype)) {
       component = <FileAudio id={id} url={url} type={mimetype} sx={sx} />;
-    } else if (MIME_TYPES.VIDEO.includes(mimetype)) {
+    } else if (MIME_TYPES.isVideo(mimetype)) {
       // does not specify mimetype in video source, this way, it works with more container formats in more browsers (especially Chrome with video/quicktime)
       component = <FileVideo id={id} url={url} sx={sx} />;
-    } else if (MIME_TYPES.PDF.includes(mimetype)) {
+    } else if (MIME_TYPES.isPdf(mimetype)) {
       component = (
         <FilePdf
           id={id}

--- a/src/items/FileItem.tsx
+++ b/src/items/FileItem.tsx
@@ -6,7 +6,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import {
   LocalFileItemExtra,
-  MIME_TYPES,
+  MimeTypes,
   S3FileItemExtra,
   getFileExtra,
   getS3FileExtra,
@@ -116,14 +116,14 @@ const FileItem: FC<FileItemProps> = ({
 
   let component;
   if (mimetype) {
-    if (MIME_TYPES.isImage(mimetype)) {
+    if (MimeTypes.isImage(mimetype)) {
       component = <FileImage id={id} url={url} alt={name} sx={sx} />;
-    } else if (MIME_TYPES.isAudio(mimetype)) {
+    } else if (MimeTypes.isAudio(mimetype)) {
       component = <FileAudio id={id} url={url} type={mimetype} sx={sx} />;
-    } else if (MIME_TYPES.isVideo(mimetype)) {
+    } else if (MimeTypes.isVideo(mimetype)) {
       // does not specify mimetype in video source, this way, it works with more container formats in more browsers (especially Chrome with video/quicktime)
       component = <FileVideo id={id} url={url} sx={sx} />;
-    } else if (MIME_TYPES.isPdf(mimetype)) {
+    } else if (MimeTypes.isPdf(mimetype)) {
       component = (
         <FilePdf
           id={id}

--- a/src/items/S3FileItem.tsx
+++ b/src/items/S3FileItem.tsx
@@ -3,7 +3,7 @@ import Alert from '@mui/material/Alert';
 
 import React, { useEffect, useState } from 'react';
 
-import { MIME_TYPES, getS3FileExtra } from '@graasp/sdk';
+import { MimeTypes, getS3FileExtra } from '@graasp/sdk';
 import { S3FileItemTypeRecord } from '@graasp/sdk/frontend';
 
 import Loader from '../Loader';
@@ -81,19 +81,19 @@ const S3FileItem = ({
 
   let component;
   if (mimetype) {
-    if (MIME_TYPES.isImage(mimetype)) {
+    if (MimeTypes.isImage(mimetype)) {
       component = <FileImage id={id} url={url} alt={name} sx={sx} />;
     }
 
-    if (MIME_TYPES.isAudio(mimetype)) {
+    if (MimeTypes.isAudio(mimetype)) {
       component = <FileAudio id={id} url={url} type={mimetype} sx={sx} />;
     }
 
-    if (MIME_TYPES.isVideo(mimetype)) {
+    if (MimeTypes.isVideo(mimetype)) {
       component = <FileVideo id={id} url={url} sx={sx} />;
     }
 
-    if (MIME_TYPES.isPdf(mimetype)) {
+    if (MimeTypes.isPdf(mimetype)) {
       component = <FilePdf id={id} url={url} height={maxHeight} sx={sx} />;
     }
   }

--- a/src/items/S3FileItem.tsx
+++ b/src/items/S3FileItem.tsx
@@ -3,11 +3,11 @@ import Alert from '@mui/material/Alert';
 
 import React, { useEffect, useState } from 'react';
 
-import { getS3FileExtra } from '@graasp/sdk';
+import { MIME_TYPES, getS3FileExtra } from '@graasp/sdk';
 import { S3FileItemTypeRecord } from '@graasp/sdk/frontend';
 
 import Loader from '../Loader';
-import { MIME_TYPES, UNEXPECTED_ERROR_MESSAGE } from '../constants';
+import { UNEXPECTED_ERROR_MESSAGE } from '../constants';
 import { ERRORS } from '../enums';
 import DownloadButtonFileItem from './DownloadButtonFileItem';
 import FileAudio from './FileAudio';
@@ -81,19 +81,19 @@ const S3FileItem = ({
 
   let component;
   if (mimetype) {
-    if (MIME_TYPES.IMAGE.includes(mimetype)) {
+    if (MIME_TYPES.isImage(mimetype)) {
       component = <FileImage id={id} url={url} alt={name} sx={sx} />;
     }
 
-    if (MIME_TYPES.AUDIO.includes(mimetype)) {
+    if (MIME_TYPES.isAudio(mimetype)) {
       component = <FileAudio id={id} url={url} type={mimetype} sx={sx} />;
     }
 
-    if (MIME_TYPES.VIDEO.includes(mimetype)) {
+    if (MIME_TYPES.isVideo(mimetype)) {
       component = <FileVideo id={id} url={url} sx={sx} />;
     }
 
-    if (MIME_TYPES.PDF.includes(mimetype)) {
+    if (MIME_TYPES.isPdf(mimetype)) {
       component = <FilePdf id={id} url={url} height={maxHeight} sx={sx} />;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,6 @@ export type TooltipPlacement =
 
 export type IconSizeVariant = 'small' | 'medium' | 'large' | 'inherit';
 
-export type ThumbnailSizeVariant = 'small' | 'medium' | 'large' | 'original';
-
 export enum ActionButton {
   ICON_BUTTON = 'icon',
   MENU_ITEM = 'menuItem',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,9 +2337,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@graasp/sdk@npm:0.8.0"
+"@graasp/sdk@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@graasp/sdk@npm:0.8.1"
   dependencies:
     "@fastify/secure-session": 5.3.0
     aws-sdk: 2.1310.0
@@ -2350,7 +2350,7 @@ __metadata:
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 9.0.0
-  checksum: c2bdb0e0dc38b2636ca3698e30dd90dcf5eb2e01bf4b6af28b5fd2310e6ae167012cbbd4d1217ef3acc19da5bbc810e02fcd649a24cfc10d1937213762ef9266
+  checksum: b2e8dec4aa624faef523e3452d117d6d565c474b5a51edbd4c98de0d1d0cf515fa067d5e47ffe57ac84a76668e15b473363df181cfcdf07cd0942f82a2c9281e
   languageName: node
   linkType: hard
 
@@ -2366,7 +2366,7 @@ __metadata:
     "@commitlint/config-conventional": 17.4.4
     "@emotion/react": 11.10.6
     "@emotion/styled": 11.10.6
-    "@graasp/sdk": 0.8.0
+    "@graasp/sdk": 0.8.1
     "@mdx-js/react": 1.6.22
     "@mui/icons-material": 5.11.9
     "@mui/lab": 5.0.0-alpha.120

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,9 +2337,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@graasp/sdk@npm:0.6.0"
+"@graasp/sdk@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@graasp/sdk@npm:0.8.0"
   dependencies:
     "@fastify/secure-session": 5.3.0
     aws-sdk: 2.1310.0
@@ -2350,7 +2350,7 @@ __metadata:
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 9.0.0
-  checksum: 450ec10d93b2139ea21728b6ce633e6947092707b1caa66055a0a251607b0c2b28ed03d3c9baa1864e930a460289927209256aef7509e7b8ff4973d17703a2ba
+  checksum: c2bdb0e0dc38b2636ca3698e30dd90dcf5eb2e01bf4b6af28b5fd2310e6ae167012cbbd4d1217ef3acc19da5bbc810e02fcd649a24cfc10d1937213762ef9266
   languageName: node
   linkType: hard
 
@@ -2366,7 +2366,7 @@ __metadata:
     "@commitlint/config-conventional": 17.4.4
     "@emotion/react": 11.10.6
     "@emotion/styled": 11.10.6
-    "@graasp/sdk": 0.6.0
+    "@graasp/sdk": 0.8.0
     "@mdx-js/react": 1.6.22
     "@mui/icons-material": 5.11.9
     "@mui/lab": 5.0.0-alpha.120


### PR DESCRIPTION
This PR uses sdk verion `0.8.0` and updates the usage of `MIME_TYPES` and `ThumbnailSize` to the ones provided by sdk.

closes #273