### PR TITLE
feat: add etherpad logo

### DIFF
--- a/src/icons/EtherpadIcon.stories.tsx
+++ b/src/icons/EtherpadIcon.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import React from 'react';
+
+import EtherpadIcon from './EtherpadIcon';
+
+export default {
+  title: 'Icons/EtherpadIcon',
+  component: EtherpadIcon,
+} as ComponentMeta<typeof EtherpadIcon>;
+
+const Template: ComponentStory<typeof EtherpadIcon> = (args) => (
+  <EtherpadIcon {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/icons/EtherpadIcon.tsx
+++ b/src/icons/EtherpadIcon.tsx
@@ -1,195 +1,130 @@
+import { SvgIcon, SxProps, Theme } from '@mui/material';
+
 import React from 'react';
 
+import { PRIMARY_COLOR } from '../theme';
+
 type Props = {
-  color: string;
+  style?: { color?: string };
+  sx?: SxProps<Theme>;
 };
 
-const EtherpadIcon = ({ color = '#ccc' }: Props): JSX.Element => (
-  <svg
-    width='340'
-    height='340'
-    viewBox='0 0 340 340'
-    version='1.1'
-    id='svg148'
-    xmlnsXlink='http://www.w3.org/1999/xlink'
-    xmlns='http://www.w3.org/2000/svg'
-  >
-    <title id='title93'>Group 10</title>
-    <defs id='defs124'>
-      <rect id='path-2' x='42' y='167' width='168' height='27' rx='13.5' />
-      <filter
-        x='-0.057142857'
-        y='-0.35555556'
-        width='1.1142857'
-        height='2.0074074'
-        filterUnits='objectBoundingBox'
-        id='filter-3'
-      >
-        <feOffset
-          dx='0'
-          dy='8'
-          in='SourceAlpha'
-          result='shadowOffsetOuter1'
-          id='feOffset101'
-        />
-        <feGaussianBlur
-          stdDeviation='4'
-          in='shadowOffsetOuter1'
-          result='shadowBlurOuter1'
-          id='feGaussianBlur103'
-        />
-        <feColorMatrix
-          values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
-          type='matrix'
-          in='shadowBlurOuter1'
-          id='feColorMatrix105'
-        />
-      </filter>
-      <rect id='path-4' x='41' y='110' width='142' height='25' rx='12.5' />
-      <filter
-        x='-0.067605637'
-        y='-0.384'
-        width='1.1352113'
-        height='2.0880001'
-        filterUnits='objectBoundingBox'
-        id='filter-5'
-      >
-        <feOffset
-          dx='0'
-          dy='8'
-          in='SourceAlpha'
-          result='shadowOffsetOuter1'
-          id='feOffset109'
-        />
-        <feGaussianBlur
-          stdDeviation='4'
-          in='shadowOffsetOuter1'
-          result='shadowBlurOuter1'
-          id='feGaussianBlur111'
-        />
-        <feColorMatrix
-          values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
-          type='matrix'
-          in='shadowBlurOuter1'
-          id='feColorMatrix113'
-        />
-      </filter>
-      <rect id='path-6' x='41' y='226' width='105' height='25' rx='12.5' />
-      <filter
-        x='-0.09142857'
-        y='-0.384'
-        width='1.1828572'
-        height='2.0880001'
-        filterUnits='objectBoundingBox'
-        id='filter-7'
-      >
-        <feOffset
-          dx='0'
-          dy='8'
-          in='SourceAlpha'
-          result='shadowOffsetOuter1'
-          id='feOffset117'
-        />
-        <feGaussianBlur
-          stdDeviation='4'
-          in='shadowOffsetOuter1'
-          result='shadowBlurOuter1'
-          id='feGaussianBlur119'
-        />
-        <feColorMatrix
-          values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
-          type='matrix'
-          in='shadowBlurOuter1'
-          id='feColorMatrix121'
-        />
-      </filter>
-    </defs>
-    <g
-      id='Page-1'
-      stroke='none'
-      stroke-width='1'
-      fill='none'
-      fill-rule='evenodd'
-      transform='translate(0,-15)'
+const EtherpadIcon = ({ style, sx }: Props) => {
+  const color = style?.color ?? PRIMARY_COLOR;
+
+  return (
+    <SvgIcon
+      viewBox='0 0 340 340'
+      version='1.1'
+      id='svg148'
+      xmlnsXlink='http://www.w3.org/1999/xlink'
+      xmlns='http://www.w3.org/2000/svg'
+      sx={sx}
     >
-      <g id='Group-5-Copy-2' transform='translate(-415,-351)'>
-        <g id='Group-10' transform='translate(415,351)'>
-          <g id='Group-9' transform='translate(0,15)'>
-            <rect
-              id='Rectangle-Copy-54'
-              fill={color}
-              x='0'
-              y='0'
-              width='340'
-              height='340'
-              rx='70'
-            />
-            <path
-              d='m 237.61221,138.15765 c -2.88643,-2.87573 -7.56096,-2.87801 -10.44739,0 -2.88643,2.87801 -2.88643,7.54118 0,10.41919 7.77506,7.75237 12.05791,18.02454 12.05791,28.92256 0,10.89802 -4.28285,21.17019 -12.05791,28.9253 -2.88643,2.87573 -2.88643,7.54117 0,10.41691 1.44345,1.43877 3.33243,2.15839 5.2237,2.15839 1.88898,0 3.78025,-0.71962 5.22369,-2.15839 C 248.18012,206.30453 254,192.33415 254,177.4994 c 0,-14.83429 -5.81988,-28.80467 -16.38779,-39.34175 z'
-              id='Path-Copy-26'
-              fill-opacity='0.200482'
-              fill='#000000'
-              fill-rule='nonzero'
-              opacity='0.754065'
-            />
-            <path
-              d='m 267.33303,113.15866 c -2.82254,-2.87821 -7.39359,-2.87821 -10.21613,0 -2.82253,2.88049 -2.82253,7.55042 0,10.42818 28.58694,29.1762 28.58694,76.6508 0,105.82701 -2.82253,2.87821 -2.82253,7.54768 0,10.42589 1.41149,1.44048 3.25866,2.16026 5.10806,2.16026 1.8494,0 3.69657,-0.72024 5.10807,-2.16299 34.22263,-34.92443 34.22263,-91.753 0,-126.67835 z'
-              id='Path-Copy-27'
-              fill-opacity='0.250565'
-              fill='#131514'
-              fill-rule='nonzero'
-              opacity='0.754065'
-            />
-            <g id='Rectangle-Copy-55'>
-              <use
-                fill='#000000'
-                fill-opacity='1'
-                filter='url(#filter-3)'
-                xlinkHref='#path-2'
-                id='use129'
+      <defs>
+        <rect id='path-2' x='42' y='167' width='168' height='27' rx='13.5' />
+        <filter
+          id='filter-3'
+          x='-.057143'
+          y='-.35556'
+          width='1.1143'
+          height='2.0074'
+        >
+          <feOffset
+            dx='0'
+            dy='8'
+            in='SourceAlpha'
+            result='shadowOffsetOuter1'
+          />
+          <feGaussianBlur
+            in='shadowOffsetOuter1'
+            result='shadowBlurOuter1'
+            stdDeviation='4'
+          />
+          <feColorMatrix
+            in='shadowBlurOuter1'
+            values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
+          />
+        </filter>
+        <rect id='path-4' x='41' y='110' width='142' height='25' rx='12.5' />
+        <filter
+          id='filter-5'
+          x='-.067606'
+          y='-.384'
+          width='1.1352'
+          height='2.088'
+        >
+          <feOffset
+            dx='0'
+            dy='8'
+            in='SourceAlpha'
+            result='shadowOffsetOuter1'
+          />
+          <feGaussianBlur
+            in='shadowOffsetOuter1'
+            result='shadowBlurOuter1'
+            stdDeviation='4'
+          />
+          <feColorMatrix
+            in='shadowBlurOuter1'
+            values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
+          />
+        </filter>
+        <rect id='path-6' x='41' y='226' width='105' height='25' rx='12.5' />
+        <filter
+          id='filter-7'
+          x='-.091429'
+          y='-.384'
+          width='1.1829'
+          height='2.088'
+        >
+          <feOffset
+            dx='0'
+            dy='8'
+            in='SourceAlpha'
+            result='shadowOffsetOuter1'
+          />
+          <feGaussianBlur
+            in='shadowOffsetOuter1'
+            result='shadowBlurOuter1'
+            stdDeviation='4'
+          />
+          <feColorMatrix
+            in='shadowBlurOuter1'
+            values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
+          />
+        </filter>
+      </defs>
+      <g transform='translate(0,-15)' fill='none' fill-rule='evenodd'>
+        <g transform='translate(-415,-351)'>
+          <g transform='translate(415,351)'>
+            <g transform='translate(0,15)'>
+              <rect width='340' height='340' rx='70' fill={color} />
+              <path
+                d='m237.61 138.16c-2.8864-2.8757-7.561-2.878-10.447 0s-2.8864 7.5412 0 10.419c7.7751 7.7524 12.058 18.025 12.058 28.923s-4.2828 21.17-12.058 28.925c-2.8864 2.8757-2.8864 7.5412 0 10.417 1.4434 1.4388 3.3324 2.1584 5.2237 2.1584 1.889 0 3.7802-0.71962 5.2237-2.1584 10.568-10.537 16.388-24.507 16.388-39.342 0-14.834-5.8199-28.805-16.388-39.342z'
+                fill='#000'
+                fill-opacity='.20048'
+                fill-rule='nonzero'
+                opacity='.75406'
               />
-              <use
-                fill='#ffffff'
-                fill-rule='evenodd'
-                xlinkHref='#path-2'
-                id='use131'
+              <path
+                d='m267.33 113.16c-2.8225-2.8782-7.3936-2.8782-10.216 0-2.8225 2.8805-2.8225 7.5504 0 10.428 28.587 29.176 28.587 76.651 0 105.83-2.8225 2.8782-2.8225 7.5477 0 10.426 1.4115 1.4405 3.2587 2.1603 5.1081 2.1603s3.6966-0.72024 5.1081-2.163c34.223-34.924 34.223-91.753 0-126.68z'
+                fill='#131514'
+                fill-opacity='.25056'
+                fill-rule='nonzero'
+                opacity='.75406'
               />
-            </g>
-            <g id='Rectangle-Copy-56'>
-              <use
-                fill='#000000'
-                fill-opacity='1'
-                filter='url(#filter-5)'
-                xlinkHref='#path-4'
-                id='use134'
-              />
-              <use
-                fill='#ffffff'
-                fill-rule='evenodd'
-                xlinkHref='#path-4'
-                id='use136'
-              />
-            </g>
-            <g id='Rectangle-Copy-57'>
-              <use
-                fill='#000000'
-                fill-opacity='1'
-                filter='url(#filter-7)'
-                xlinkHref='#path-6'
-                id='use139'
-              />
-              <use
-                fill='#ffffff'
-                fill-rule='evenodd'
-                xlinkHref='#path-6'
-                id='use141'
-              />
+              <use fill='#000000' filter='url(#filter-3)' xlinkHref='#path-2' />
+              <use fill='#ffffff' fill-rule='evenodd' xlinkHref='#path-2' />
+              <use fill='#000000' filter='url(#filter-5)' xlinkHref='#path-4' />
+              <use fill='#ffffff' fill-rule='evenodd' xlinkHref='#path-4' />
+              <use fill='#000000' filter='url(#filter-7)' xlinkHref='#path-6' />
+              <use fill='#ffffff' fill-rule='evenodd' xlinkHref='#path-6' />
             </g>
           </g>
         </g>
       </g>
-    </g>
-  </svg>
-);
-
+    </SvgIcon>
+  );
+};
 export default EtherpadIcon;

--- a/src/icons/EtherpadIcon.tsx
+++ b/src/icons/EtherpadIcon.tsx
@@ -2,15 +2,13 @@ import { SvgIcon, SxProps, Theme } from '@mui/material';
 
 import React from 'react';
 
-import { PRIMARY_COLOR } from '../theme';
-
 type Props = {
   style?: { color?: string };
   sx?: SxProps<Theme>;
 };
 
-const EtherpadIcon = ({ style, sx }: Props) => {
-  const color = style?.color ?? PRIMARY_COLOR;
+const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
+  const color = style?.color ?? 'rgba(0, 0, 0, 0.87)';
 
   return (
     <SvgIcon

--- a/src/icons/EtherpadIcon.tsx
+++ b/src/icons/EtherpadIcon.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+
+type Props = {
+  color: string;
+};
+
+const EtherpadIcon = ({ color = '#ccc' }: Props): JSX.Element => (
+  <svg
+    width='340'
+    height='340'
+    viewBox='0 0 340 340'
+    version='1.1'
+    id='svg148'
+    xmlnsXlink='http://www.w3.org/1999/xlink'
+    xmlns='http://www.w3.org/2000/svg'
+  >
+    <title id='title93'>Group 10</title>
+    <defs id='defs124'>
+      <rect id='path-2' x='42' y='167' width='168' height='27' rx='13.5' />
+      <filter
+        x='-0.057142857'
+        y='-0.35555556'
+        width='1.1142857'
+        height='2.0074074'
+        filterUnits='objectBoundingBox'
+        id='filter-3'
+      >
+        <feOffset
+          dx='0'
+          dy='8'
+          in='SourceAlpha'
+          result='shadowOffsetOuter1'
+          id='feOffset101'
+        />
+        <feGaussianBlur
+          stdDeviation='4'
+          in='shadowOffsetOuter1'
+          result='shadowBlurOuter1'
+          id='feGaussianBlur103'
+        />
+        <feColorMatrix
+          values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
+          type='matrix'
+          in='shadowBlurOuter1'
+          id='feColorMatrix105'
+        />
+      </filter>
+      <rect id='path-4' x='41' y='110' width='142' height='25' rx='12.5' />
+      <filter
+        x='-0.067605637'
+        y='-0.384'
+        width='1.1352113'
+        height='2.0880001'
+        filterUnits='objectBoundingBox'
+        id='filter-5'
+      >
+        <feOffset
+          dx='0'
+          dy='8'
+          in='SourceAlpha'
+          result='shadowOffsetOuter1'
+          id='feOffset109'
+        />
+        <feGaussianBlur
+          stdDeviation='4'
+          in='shadowOffsetOuter1'
+          result='shadowBlurOuter1'
+          id='feGaussianBlur111'
+        />
+        <feColorMatrix
+          values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
+          type='matrix'
+          in='shadowBlurOuter1'
+          id='feColorMatrix113'
+        />
+      </filter>
+      <rect id='path-6' x='41' y='226' width='105' height='25' rx='12.5' />
+      <filter
+        x='-0.09142857'
+        y='-0.384'
+        width='1.1828572'
+        height='2.0880001'
+        filterUnits='objectBoundingBox'
+        id='filter-7'
+      >
+        <feOffset
+          dx='0'
+          dy='8'
+          in='SourceAlpha'
+          result='shadowOffsetOuter1'
+          id='feOffset117'
+        />
+        <feGaussianBlur
+          stdDeviation='4'
+          in='shadowOffsetOuter1'
+          result='shadowBlurOuter1'
+          id='feGaussianBlur119'
+        />
+        <feColorMatrix
+          values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
+          type='matrix'
+          in='shadowBlurOuter1'
+          id='feColorMatrix121'
+        />
+      </filter>
+    </defs>
+    <g
+      id='Page-1'
+      stroke='none'
+      stroke-width='1'
+      fill='none'
+      fill-rule='evenodd'
+      transform='translate(0,-15)'
+    >
+      <g id='Group-5-Copy-2' transform='translate(-415,-351)'>
+        <g id='Group-10' transform='translate(415,351)'>
+          <g id='Group-9' transform='translate(0,15)'>
+            <rect
+              id='Rectangle-Copy-54'
+              fill={color}
+              x='0'
+              y='0'
+              width='340'
+              height='340'
+              rx='70'
+            />
+            <path
+              d='m 237.61221,138.15765 c -2.88643,-2.87573 -7.56096,-2.87801 -10.44739,0 -2.88643,2.87801 -2.88643,7.54118 0,10.41919 7.77506,7.75237 12.05791,18.02454 12.05791,28.92256 0,10.89802 -4.28285,21.17019 -12.05791,28.9253 -2.88643,2.87573 -2.88643,7.54117 0,10.41691 1.44345,1.43877 3.33243,2.15839 5.2237,2.15839 1.88898,0 3.78025,-0.71962 5.22369,-2.15839 C 248.18012,206.30453 254,192.33415 254,177.4994 c 0,-14.83429 -5.81988,-28.80467 -16.38779,-39.34175 z'
+              id='Path-Copy-26'
+              fill-opacity='0.200482'
+              fill='#000000'
+              fill-rule='nonzero'
+              opacity='0.754065'
+            />
+            <path
+              d='m 267.33303,113.15866 c -2.82254,-2.87821 -7.39359,-2.87821 -10.21613,0 -2.82253,2.88049 -2.82253,7.55042 0,10.42818 28.58694,29.1762 28.58694,76.6508 0,105.82701 -2.82253,2.87821 -2.82253,7.54768 0,10.42589 1.41149,1.44048 3.25866,2.16026 5.10806,2.16026 1.8494,0 3.69657,-0.72024 5.10807,-2.16299 34.22263,-34.92443 34.22263,-91.753 0,-126.67835 z'
+              id='Path-Copy-27'
+              fill-opacity='0.250565'
+              fill='#131514'
+              fill-rule='nonzero'
+              opacity='0.754065'
+            />
+            <g id='Rectangle-Copy-55'>
+              <use
+                fill='#000000'
+                fill-opacity='1'
+                filter='url(#filter-3)'
+                xlinkHref='#path-2'
+                id='use129'
+              />
+              <use
+                fill='#ffffff'
+                fill-rule='evenodd'
+                xlinkHref='#path-2'
+                id='use131'
+              />
+            </g>
+            <g id='Rectangle-Copy-56'>
+              <use
+                fill='#000000'
+                fill-opacity='1'
+                filter='url(#filter-5)'
+                xlinkHref='#path-4'
+                id='use134'
+              />
+              <use
+                fill='#ffffff'
+                fill-rule='evenodd'
+                xlinkHref='#path-4'
+                id='use136'
+              />
+            </g>
+            <g id='Rectangle-Copy-57'>
+              <use
+                fill='#000000'
+                fill-opacity='1'
+                filter='url(#filter-7)'
+                xlinkHref='#path-6'
+                id='use139'
+              />
+              <use
+                fill='#ffffff'
+                fill-rule='evenodd'
+                xlinkHref='#path-6'
+                id='use141'
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </svg>
+);
+
+export default EtherpadIcon;

--- a/src/icons/EtherpadIcon.tsx
+++ b/src/icons/EtherpadIcon.tsx
@@ -12,7 +12,7 @@ const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
 
   return (
     <SvgIcon
-      viewBox='0 0 380 380'
+      viewBox='0 0 420 420'
       version='1.1'
       id='svg148'
       xmlnsXlink='http://www.w3.org/1999/xlink'
@@ -75,22 +75,20 @@ const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
           />
         </filter>
       </defs>
-      <g transform='translate(20,5)' fill='none' fill-rule='evenodd'>
+      <g transform='translate(40,25)' fill='none' fill-rule='evenodd'>
         <g transform='translate(-415,-351)'>
           <g transform='translate(415,351)'>
             <g transform='translate(0,15)'>
               <rect width='340' height='340' rx='70' fill={color} />
               <path
-                d='m238 138c-2.89-2.88-7.56-2.88-10.4 0s-2.89 7.54 0 10.4c7.78 7.75 12.1 18 12.1 28.9s-4.28 21.2-12.1 28.9c-2.89 2.88-2.89 7.54 0 10.4 1.44 1.44 3.33 2.16 5.22 2.16 1.89 0 3.78-0.72 5.22-2.16 10.6-10.5 16.4-24.5 16.4-39.3 0-14.8-5.82-28.8-16.4-39.3z'
+                d='m238 138c-2.89-2.88-7.56-2.88-10.4 0s-2.89 7.54 0 10.4c7.78 7.75 12.1 18 12.1 28.9s-4.28 21.2-12.1 28.9c-2.89 2.88-2.89 7.54 0 10.4 1.44 1.44 3.33 2.16 5.22 2.16s3.78-0.72 5.22-2.16c10.6-10.5 16.4-24.5 16.4-39.3s-5.82-28.8-16.4-39.3z'
                 fill='#fff'
-                fill-opacity='1'
                 fill-rule='nonzero'
                 opacity='.754'
               />
               <path
                 d='m267 113c-2.82-2.88-7.39-2.88-10.2 0-2.82 2.88-2.82 7.55 0 10.4 28.6 29.2 28.6 76.7 0 106-2.82 2.88-2.82 7.55 0 10.4 1.41 1.44 3.26 2.16 5.11 2.16s3.7-0.72 5.11-2.16c34.2-34.9 34.2-91.8 0-127z'
                 fill='#fff'
-                fill-opacity='1'
                 fill-rule='nonzero'
                 opacity='.754'
               />

--- a/src/icons/EtherpadIcon.tsx
+++ b/src/icons/EtherpadIcon.tsx
@@ -12,7 +12,7 @@ const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
 
   return (
     <SvgIcon
-      viewBox='0 0 340 340'
+      viewBox='0 0 380 380'
       version='1.1'
       id='svg148'
       xmlnsXlink='http://www.w3.org/1999/xlink'
@@ -20,14 +20,8 @@ const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
       sx={sx}
     >
       <defs>
-        <rect id='path-2' x='42' y='167' width='168' height='27' rx='13.5' />
-        <filter
-          id='filter-3'
-          x='-.057143'
-          y='-.35556'
-          width='1.1143'
-          height='2.0074'
-        >
+        <rect id='c' x='42' y='167' width='168' height='27' rx='13.5' />
+        <filter id='f' x='-.0571' y='-.356' width='1.11' height='2.01'>
           <feOffset
             dx='0'
             dy='8'
@@ -44,14 +38,8 @@ const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
             values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
           />
         </filter>
-        <rect id='path-4' x='41' y='110' width='142' height='25' rx='12.5' />
-        <filter
-          id='filter-5'
-          x='-.067606'
-          y='-.384'
-          width='1.1352'
-          height='2.088'
-        >
+        <rect id='b' x='41' y='110' width='142' height='25' rx='12.5' />
+        <filter id='e' x='-.0676' y='-.384' width='1.14' height='2.09'>
           <feOffset
             dx='0'
             dy='8'
@@ -68,14 +56,8 @@ const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
             values='0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.0568181818 0'
           />
         </filter>
-        <rect id='path-6' x='41' y='226' width='105' height='25' rx='12.5' />
-        <filter
-          id='filter-7'
-          x='-.091429'
-          y='-.384'
-          width='1.1829'
-          height='2.088'
-        >
+        <rect id='a' x='41' y='226' width='105' height='25' rx='12.5' />
+        <filter id='d' x='-.0914' y='-.384' width='1.18' height='2.09'>
           <feOffset
             dx='0'
             dy='8'
@@ -93,31 +75,67 @@ const EtherpadIcon = ({ style, sx }: Props): JSX.Element => {
           />
         </filter>
       </defs>
-      <g transform='translate(0,-15)' fill='none' fill-rule='evenodd'>
+      <g transform='translate(20,5)' fill='none' fill-rule='evenodd'>
         <g transform='translate(-415,-351)'>
           <g transform='translate(415,351)'>
             <g transform='translate(0,15)'>
               <rect width='340' height='340' rx='70' fill={color} />
               <path
-                d='m237.61 138.16c-2.8864-2.8757-7.561-2.878-10.447 0s-2.8864 7.5412 0 10.419c7.7751 7.7524 12.058 18.025 12.058 28.923s-4.2828 21.17-12.058 28.925c-2.8864 2.8757-2.8864 7.5412 0 10.417 1.4434 1.4388 3.3324 2.1584 5.2237 2.1584 1.889 0 3.7802-0.71962 5.2237-2.1584 10.568-10.537 16.388-24.507 16.388-39.342 0-14.834-5.8199-28.805-16.388-39.342z'
-                fill='#000'
-                fill-opacity='.20048'
+                d='m238 138c-2.89-2.88-7.56-2.88-10.4 0s-2.89 7.54 0 10.4c7.78 7.75 12.1 18 12.1 28.9s-4.28 21.2-12.1 28.9c-2.89 2.88-2.89 7.54 0 10.4 1.44 1.44 3.33 2.16 5.22 2.16 1.89 0 3.78-0.72 5.22-2.16 10.6-10.5 16.4-24.5 16.4-39.3 0-14.8-5.82-28.8-16.4-39.3z'
+                fill='#fff'
+                fill-opacity='1'
                 fill-rule='nonzero'
-                opacity='.75406'
+                opacity='.754'
               />
               <path
-                d='m267.33 113.16c-2.8225-2.8782-7.3936-2.8782-10.216 0-2.8225 2.8805-2.8225 7.5504 0 10.428 28.587 29.176 28.587 76.651 0 105.83-2.8225 2.8782-2.8225 7.5477 0 10.426 1.4115 1.4405 3.2587 2.1603 5.1081 2.1603s3.6966-0.72024 5.1081-2.163c34.223-34.924 34.223-91.753 0-126.68z'
-                fill='#131514'
-                fill-opacity='.25056'
+                d='m267 113c-2.82-2.88-7.39-2.88-10.2 0-2.82 2.88-2.82 7.55 0 10.4 28.6 29.2 28.6 76.7 0 106-2.82 2.88-2.82 7.55 0 10.4 1.41 1.44 3.26 2.16 5.11 2.16s3.7-0.72 5.11-2.16c34.2-34.9 34.2-91.8 0-127z'
+                fill='#fff'
+                fill-opacity='1'
                 fill-rule='nonzero'
-                opacity='.75406'
+                opacity='.754'
               />
-              <use fill='#000000' filter='url(#filter-3)' xlinkHref='#path-2' />
-              <use fill='#ffffff' fill-rule='evenodd' xlinkHref='#path-2' />
-              <use fill='#000000' filter='url(#filter-5)' xlinkHref='#path-4' />
-              <use fill='#ffffff' fill-rule='evenodd' xlinkHref='#path-4' />
-              <use fill='#000000' filter='url(#filter-7)' xlinkHref='#path-6' />
-              <use fill='#ffffff' fill-rule='evenodd' xlinkHref='#path-6' />
+              <use
+                width='100%'
+                height='100%'
+                fill='#000000'
+                filter='url(#f)'
+                xlinkHref='#c'
+              />
+              <use
+                width='100%'
+                height='100%'
+                fill='#ffffff'
+                fill-rule='evenodd'
+                xlinkHref='#c'
+              />
+              <use
+                width='100%'
+                height='100%'
+                fill='#000000'
+                filter='url(#e)'
+                xlinkHref='#b'
+              />
+              <use
+                width='100%'
+                height='100%'
+                fill='#ffffff'
+                fill-rule='evenodd'
+                xlinkHref='#b'
+              />
+              <use
+                width='100%'
+                height='100%'
+                fill='#000000'
+                filter='url(#d)'
+                xlinkHref='#a'
+              />
+              <use
+                width='100%'
+                height='100%'
+                fill='#ffffff'
+                fill-rule='evenodd'
+                xlinkHref='#a'
+              />
             </g>
           </g>
         </g>

--- a/src/icons/ItemIcon.tsx
+++ b/src/icons/ItemIcon.tsx
@@ -10,11 +10,8 @@ import Looks5Icon from '@mui/icons-material/Looks5';
 import MovieIcon from '@mui/icons-material/Movie';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
-import { SvgIcon, SvgIconTypeMap, SxProps } from '@mui/material';
-import {
-  OverridableComponent,
-  OverridableTypeMap,
-} from '@mui/material/OverridableComponent';
+import { SvgIconTypeMap, SxProps } from '@mui/material';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
 
 import React, { FC } from 'react';
 

--- a/src/icons/ItemIcon.tsx
+++ b/src/icons/ItemIcon.tsx
@@ -2,7 +2,6 @@ import AppsIcon from '@mui/icons-material/Apps';
 import DescriptionIcon from '@mui/icons-material/Description';
 import FolderIcon from '@mui/icons-material/Folder';
 import FolderZipIcon from '@mui/icons-material/FolderZip';
-import GroupsIcon from '@mui/icons-material/Groups';
 import ImageIcon from '@mui/icons-material/Image';
 import ShortcutIcon from '@mui/icons-material/Input';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
@@ -11,7 +10,11 @@ import Looks5Icon from '@mui/icons-material/Looks5';
 import MovieIcon from '@mui/icons-material/Movie';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
-import { SxProps } from '@mui/material';
+import { SvgIcon, SvgIconTypeMap, SxProps } from '@mui/material';
+import {
+  OverridableComponent,
+  OverridableTypeMap,
+} from '@mui/material/OverridableComponent';
 
 import React, { FC } from 'react';
 
@@ -28,6 +31,7 @@ import { ItemRecord } from '@graasp/sdk/frontend';
 
 import { StyledImage } from '../StyledComponents/StyledBaseComponents';
 import { ITEM_ICON_MAX_SIZE } from '../constants';
+import EtherpadIcon from './EtherpadIcon';
 
 export interface ItemIconProps {
   alt: string;
@@ -79,7 +83,7 @@ const ItemIcon: FC<ItemIconProps> = ({
     );
   }
 
-  let Icon = InsertDriveFileIcon;
+  let Icon: OverridableComponent<SvgIconTypeMap> = InsertDriveFileIcon;
   switch (type) {
     case ItemType.FOLDER:
       Icon = FolderIcon;
@@ -132,7 +136,7 @@ const ItemIcon: FC<ItemIconProps> = ({
       break;
     }
     case ItemType.ETHERPAD: {
-      Icon = GroupsIcon;
+      Icon = EtherpadIcon;
       break;
     }
     default:

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,6 +1,7 @@
 export { default as AnalyticsIcon } from './AnalyticsIcon';
+export { default as BuildIcon } from './BuildIcon';
+export { default as CCLicenseIcon } from './CCLicenseIcon';
+export { default as EtherpadIcon } from './EtherpadIcon';
+export { default as ItemIcon } from './ItemIcon';
 export { default as LibraryIcon } from './LibraryIcon';
 export { default as PlayIcon } from './PlayIcon';
-export { default as BuildIcon } from './BuildIcon';
-export { default as ItemIcon } from './ItemIcon';
-export { default as CCLicenseIcon } from './CCLicenseIcon';


### PR DESCRIPTION
Closes #276 

This PR adds the etherpad logo as a SVG-in-JSX component which replaces the previously used `GroupsIcon`.