### PR TITLE
feat: add header platform colors

### DIFF
--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -5,6 +5,8 @@ import Typography from '@mui/material/Typography';
 
 import React from 'react';
 
+import { Context } from '@graasp/sdk';
+
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import Header from './Header';
 
@@ -35,4 +37,28 @@ Example.args = {
   leftContent: <Typography sx={{ ml: 2 }}>Header</Typography>,
   rightContent: <Avatar sx={{ mr: 2 }}>H</Avatar>,
   centerContent: <Typography sx={{ ml: 2 }}>Title</Typography>,
+};
+
+export const Builder = Template.bind({});
+Builder.args = {
+  ...Example.args,
+  context: Context.BUILDER,
+};
+
+export const Player = Template.bind({});
+Player.args = {
+  ...Example.args,
+  context: Context.PLAYER,
+};
+
+export const Library = Template.bind({});
+Library.args = {
+  ...Example.args,
+  context: Context.LIBRARY,
+};
+
+export const Analytics = Template.bind({});
+Analytics.args = {
+  ...Example.args,
+  context: Context.ANALYTICS,
 };

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -1,6 +1,6 @@
 import MenuIcon from '@mui/icons-material/Menu';
 import MenuOpenIcon from '@mui/icons-material/MenuOpen';
-import { Theme, styled } from '@mui/material';
+import { SxProps, Theme, styled } from '@mui/material';
 import AppBar from '@mui/material/AppBar';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
@@ -8,9 +8,16 @@ import Toolbar from '@mui/material/Toolbar';
 
 import React, { FC } from 'react';
 
+import { Context } from '@graasp/sdk';
+
 import { CLOSE_DRAWER_LABEL, OPEN_DRAWER_LABEL } from '../labels';
+import { AccentColors, PRIMARY_COLOR } from '../theme';
+
+export const buildHeaderGradient = (color: string): string =>
+  `linear-gradient(90deg, ${PRIMARY_COLOR} 0%, ${PRIMARY_COLOR} 35%, ${color} 100%);`;
 
 export type HeaderProps = {
+  context?: Context;
   centerContent?: React.ReactElement;
   handleDrawerOpen?: () => void;
   handleDrawerClose?: () => void;
@@ -22,6 +29,7 @@ export type HeaderProps = {
   openDrawerAriaLabel?: string;
   closeDrawerAriaLabel?: string;
   rightContent?: React.ReactElement;
+  sx?: SxProps;
 };
 
 const StyledIconButton = styled(IconButton)(
@@ -38,6 +46,7 @@ const StyledToolbar = styled(Toolbar)({
 });
 
 export const Header: FC<HeaderProps> = ({
+  context,
   centerContent,
   menuButtonId,
   id,
@@ -49,6 +58,7 @@ export const Header: FC<HeaderProps> = ({
   closeDrawerAriaLabel = CLOSE_DRAWER_LABEL,
   leftContent,
   rightContent,
+  sx,
 }) => {
   const renderMenuIcon = (): JSX.Element | null => {
     if (!hasSidebar) {
@@ -82,7 +92,16 @@ export const Header: FC<HeaderProps> = ({
   };
 
   return (
-    <AppBar id={id} position='fixed'>
+    <AppBar
+      id={id}
+      position='fixed'
+      sx={{
+        background: context
+          ? buildHeaderGradient(AccentColors[context])
+          : PRIMARY_COLOR,
+        ...sx,
+      }}
+    >
       <StyledToolbar disableGutters>
         {renderMenuIcon()}
         <Grid container>

--- a/src/Main/Main.tsx
+++ b/src/Main/Main.tsx
@@ -1,6 +1,8 @@
-import { styled } from '@mui/material';
+import { SxProps, styled } from '@mui/material';
 
 import React, { Component } from 'react';
+
+import { Context } from '@graasp/sdk';
 
 import Header from '../Header';
 import Sidebar from '../Sidebar';
@@ -20,6 +22,7 @@ const DrawerHeaderContainer = styled('div')(({ theme }) => ({
 }));
 
 export interface MainProps {
+  context?: Context;
   children?: JSX.Element | JSX.Element[];
   fullScreen?: boolean;
   /**
@@ -38,6 +41,7 @@ export interface MainProps {
    * Whether the sidebar is open by default
    */
   headerId?: string;
+  headerSx?: SxProps;
   open?: boolean;
   sidebar?: React.ReactElement;
   menuButtonId?: string;
@@ -108,6 +112,7 @@ export class Main extends Component<MainProps, MainState> {
     return (
       <StyledRoot>
         <Header
+          context={this.props.context}
           hasSidebar={hasSidebar}
           isSidebarOpen={open}
           handleDrawerOpen={this.handleDrawerOpen}
@@ -117,6 +122,7 @@ export class Main extends Component<MainProps, MainState> {
           centerContent={headerCenterContent}
           id={headerId}
           menuButtonId={menuButtonId}
+          sx={this.props.headerSx}
         />
 
         {hasSidebar && <Sidebar isSidebarOpen={open}>{sidebar}</Sidebar>}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,8 +1,17 @@
 import { grey } from '@mui/material/colors';
 import { createTheme } from '@mui/material/styles';
 
+import { Context } from '@graasp/sdk';
+
 export const PRIMARY_COLOR = '#5050d2';
 export const SECONDARY_COLOR = '#FFFFFF';
+
+export const AccentColors = {
+  [Context.BUILDER]: '#1ecaa5',
+  [Context.PLAYER]: '#009eff',
+  [Context.LIBRARY]: '#9300c6',
+  [Context.ANALYTICS]: '#0707a3',
+};
 
 export const theme = createTheme({
   palette: {


### PR DESCRIPTION
Closes #278 

This PR adds the platform-specific colors to the header appbar.

[Peek 2023-03-10 11-12.webm](https://user-images.githubusercontent.com/14943421/224292651-9cf86b56-45a7-4fa9-a12b-e820c42985e4.webm)
