### PR TITLE
282 display item badges on card

### DIFF
--- a/src/Card/Card.stories.tsx
+++ b/src/Card/Card.stories.tsx
@@ -6,6 +6,7 @@ import IconButton from '@mui/material/IconButton';
 
 import React from 'react';
 
+import ItemBadges from '../ItemBadges/ItemBadges';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import Card from './Card';
 
@@ -44,6 +45,34 @@ Example.args = {
       </IconButton>
     </>
   ),
+  ItemMenu: (
+    <IconButton>
+      <MoreVertIcon />
+    </IconButton>
+  ),
+};
+
+export const Badges = Template.bind({});
+Badges.args = {
+  name: 'my card title',
+  description:
+    'my card description might be really long that is why we cut it after some lines of text to allow some space for more data',
+  image: 'https://picsum.photos/200/100',
+  creator: 'graasp',
+  Actions: (
+    <>
+      <IconButton>
+        <AcUnitIcon />
+      </IconButton>
+      <IconButton>
+        <AcUnitIcon />
+      </IconButton>
+      <IconButton>
+        <AcUnitIcon />
+      </IconButton>
+    </>
+  ),
+  Badges: <ItemBadges isHidden isPublic isPublished isPinned />,
   ItemMenu: (
     <IconButton>
       <MoreVertIcon />

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -20,6 +20,7 @@ type CardProps = {
    * actions displayed at the bottom of the card
    */
   Actions?: ReactElement;
+  Badges?: ReactElement;
   cardId?: string;
   /**
    * creator name
@@ -42,6 +43,7 @@ type CardProps = {
 
 const Item: FC<CardProps> = ({
   Actions,
+  Badges,
   cardId,
   creator,
   description,
@@ -120,9 +122,19 @@ const Item: FC<CardProps> = ({
           >
             {description}
           </Typography>
-          {Actions && (
-            <CardActions sx={{ justifyContent: 'right', p: 0 }}>
-              {Actions}
+          {(Actions || Badges) && (
+            <CardActions sx={{ pt: 0, pl: 0 }}>
+              <Stack
+                width='100%'
+                alignItems='end'
+                direction='row'
+                justifyContent='space-between'
+              >
+                {Badges || <span />}
+                <Box margin={(theme) => `-${theme.spacing(1)}`}>
+                  {Actions || <span />}
+                </Box>
+              </Stack>
             </CardActions>
           )}
         </Stack>

--- a/src/ItemBadges/ItemBadges.stories.tsx
+++ b/src/ItemBadges/ItemBadges.stories.tsx
@@ -1,0 +1,22 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import React from 'react';
+
+import ItemBadges from './ItemBadges';
+
+export default {
+  title: 'Icons/ItemBadges',
+  component: ItemBadges,
+} as ComponentMeta<typeof ItemBadges>;
+
+const Template: ComponentStory<typeof ItemBadges> = (args) => (
+  <ItemBadges {...args} />
+);
+
+export const AllIcons = Template.bind({});
+AllIcons.args = {
+  isHidden: true,
+  isPinned: true,
+  isPublished: true,
+  isPublic: true,
+};

--- a/src/ItemBadges/ItemBadges.tsx
+++ b/src/ItemBadges/ItemBadges.tsx
@@ -1,5 +1,5 @@
 import { Public, PushPin, VisibilityOff } from '@mui/icons-material';
-import { Avatar, AvatarGroup } from '@mui/material';
+import { Avatar, AvatarGroup, Tooltip } from '@mui/material';
 
 import React from 'react';
 
@@ -8,40 +8,51 @@ import { ThumbnailSize } from '@graasp/sdk';
 import { LibraryIcon } from '../icons';
 
 type ItemBadgeProps = {
+  tooltip: string;
   children: JSX.Element;
 };
 
-const ItemBadge = ({ children }: ItemBadgeProps): JSX.Element => (
-  <Avatar sx={{ width: 24, height: 24 }}>{children}</Avatar>
+const ItemBadge = ({ tooltip, children }: ItemBadgeProps): JSX.Element => (
+  <Tooltip title={tooltip}>
+    <Avatar sx={{ width: 24, height: 24 }}>{children}</Avatar>
+  </Tooltip>
 );
 
 type Props = {
   isHidden?: boolean;
+  isHiddenTooltip?: string;
   isPublic?: boolean;
+  isPublicTooltip?: string;
   isPublished?: boolean;
+  isPublishedTooltip?: string;
   isPinned?: boolean;
+  isPinnedTooltip?: string;
 };
 
 const ItemBadges = ({
   isHidden = false,
-  isPublic = false,
+  isHiddenTooltip = 'Hidden',
   isPinned = false,
+  isPinnedTooltip = 'Pinned',
   isPublished = false,
+  isPublishedTooltip = 'Published',
+  isPublic = false,
+  isPublicTooltip = 'Public',
 }: Props): JSX.Element => {
   return (
     <AvatarGroup>
       {isHidden && (
-        <ItemBadge>
+        <ItemBadge tooltip={isHiddenTooltip}>
           <VisibilityOff fontSize={ThumbnailSize.Small} />
         </ItemBadge>
       )}
       {isPinned && (
-        <ItemBadge>
+        <ItemBadge tooltip={isPinnedTooltip}>
           <PushPin fontSize={ThumbnailSize.Small} />
         </ItemBadge>
       )}
       {isPublished && (
-        <ItemBadge>
+        <ItemBadge tooltip={isPublishedTooltip}>
           <LibraryIcon
             secondaryColor='white'
             primaryColor='rgb(189, 189, 189)'
@@ -50,7 +61,7 @@ const ItemBadges = ({
         </ItemBadge>
       )}
       {isPublic && (
-        <ItemBadge>
+        <ItemBadge tooltip={isPublicTooltip}>
           <Public fontSize={ThumbnailSize.Small} />
         </ItemBadge>
       )}

--- a/src/ItemBadges/ItemBadges.tsx
+++ b/src/ItemBadges/ItemBadges.tsx
@@ -1,0 +1,60 @@
+import { Public, PushPin, VisibilityOff } from '@mui/icons-material';
+import { Avatar, AvatarGroup } from '@mui/material';
+
+import React from 'react';
+
+import { ThumbnailSize } from '@graasp/sdk';
+
+import { LibraryIcon } from '../icons';
+
+type ItemBadgeProps = {
+  children: JSX.Element;
+};
+
+const ItemBadge = ({ children }: ItemBadgeProps): JSX.Element => (
+  <Avatar sx={{ width: 24, height: 24 }}>{children}</Avatar>
+);
+
+type Props = {
+  isHidden?: boolean;
+  isPublic?: boolean;
+  isPublished?: boolean;
+  isPinned?: boolean;
+};
+
+const ItemBadges = ({
+  isHidden = false,
+  isPublic = false,
+  isPinned = false,
+  isPublished = false,
+}: Props): JSX.Element => {
+  return (
+    <AvatarGroup>
+      {isHidden && (
+        <ItemBadge>
+          <VisibilityOff fontSize={ThumbnailSize.Small} />
+        </ItemBadge>
+      )}
+      {isPinned && (
+        <ItemBadge>
+          <PushPin fontSize={ThumbnailSize.Small} />
+        </ItemBadge>
+      )}
+      {isPublished && (
+        <ItemBadge>
+          <LibraryIcon
+            secondaryColor='white'
+            primaryColor='rgb(189, 189, 189)'
+            primaryOpacity={0}
+          />
+        </ItemBadge>
+      )}
+      {isPublic && (
+        <ItemBadge>
+          <Public fontSize={ThumbnailSize.Small} />
+        </ItemBadge>
+      )}
+    </AvatarGroup>
+  );
+};
+export default ItemBadges;

--- a/src/ItemBadges/index.ts
+++ b/src/ItemBadges/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ItemBadges';

--- a/src/TableComponent/Table.stories.tsx
+++ b/src/TableComponent/Table.stories.tsx
@@ -17,7 +17,12 @@ const agGridCategory = 'Ag Grid';
 const rowData = [
   { id: 1, name: 'name 1', type: 'file', updatedAt: new Date() },
   { id: 2, name: 'name 2', type: 'h5p', updatedAt: new Date() },
-  { id: 3, name: 'name 3', type: 'folder', updatedAt: new Date() },
+  {
+    id: 3,
+    name: 'name 3 is a very long file name ',
+    type: 'folder',
+    updatedAt: new Date(),
+  },
   { id: 1, name: 'name 4', type: 'file', updatedAt: new Date() },
   { id: 2, name: 'name 5', type: 'h5p', updatedAt: new Date() },
   { id: 3, name: 'name 6', type: 'folder', updatedAt: new Date() },
@@ -120,25 +125,32 @@ Simple.args = {
   tableHeight: 300,
   columnDefs: [
     {
-      headerCheckboxSelection: true,
-      checkboxSelection: true,
       field: 'name',
       headerName: 'Name',
+      headerCheckboxSelection: true,
+      checkboxSelection: true,
       // rowDrag: true,
     },
     {
       field: 'type',
       headerName: 'Type',
       type: 'rightAligned',
+      suppressSizeToFit: true,
+      maxWidth: 80,
     },
     {
       field: 'updatedAt',
       headerName: 'Updated At',
       type: 'rightAligned',
+      suppressSizeToFit: true,
+      maxWidth: 160,
       valueFormatter: dateFormatter,
     },
     {
       field: 'actions',
+      headerName: 'Actions',
+      suppressSizeToFit: true,
+      maxWidth: 100, // approx 50 per iconButton (40px + 8px margin on each side)
       suppressKeyboardEvent: Table.suppressKeyboardEventForParentCell,
       cellRenderer: ({ data }: any) => {
         return (
@@ -148,7 +160,6 @@ Simple.args = {
           </>
         );
       },
-      headerName: 'actions',
     },
   ],
   rowData,

--- a/src/TableComponent/Table.tsx
+++ b/src/TableComponent/Table.tsx
@@ -23,7 +23,7 @@ import React, {
   useState,
 } from 'react';
 
-import { DRAG_COLUMN_WIDTH, DRAG_ICON_SIZE } from '../constants';
+import { DRAG_COLUMN_WIDTH } from '../constants';
 import DragCellRenderer from './DragCellRenderer';
 import TableNoRowsContent from './TableNoRowsContent';
 import TableToolbar from './TableToolbar';
@@ -212,7 +212,7 @@ function GraaspTable<T>({
         display: 'flex',
       },
       headerClass: DRAG_CELL_CLASS_NAME,
-      width: DRAG_ICON_SIZE,
+      width: DRAG_COLUMN_WIDTH,
       maxWidth: DRAG_COLUMN_WIDTH,
       sortable: false,
       headerName: '',

--- a/src/TableComponent/Table.tsx
+++ b/src/TableComponent/Table.tsx
@@ -23,7 +23,7 @@ import React, {
   useState,
 } from 'react';
 
-import { DRAG_ICON_SIZE } from '../constants';
+import { DRAG_COLUMN_WIDTH, DRAG_ICON_SIZE } from '../constants';
 import DragCellRenderer from './DragCellRenderer';
 import TableNoRowsContent from './TableNoRowsContent';
 import TableToolbar from './TableToolbar';
@@ -75,6 +75,14 @@ const StyledDiv = styled('div')(({ theme }) => ({
     color: theme.palette.primary.main,
   },
   height: '100%',
+  '.ag-selection-checkbox, .ag-header-select-all': {
+    // reduce margin after checkbox in cells and header
+    marginRight: `${theme.spacing(2)}!important`,
+  },
+  '.ag-cell, .ag-header-cell': {
+    // reduce padding on left and right of cells
+    padding: theme.spacing(0, 1),
+  },
 }));
 
 const ROW_CLASS_NAME = 'row-class-name';
@@ -152,6 +160,8 @@ function GraaspTable<T>({
     if (!gridApi) {
       setGridApi(params.api);
     }
+    // size columns to fit the width of the screen
+    gridApi?.sizeColumnsToFit();
   };
 
   const changeSelection = (): void => {
@@ -203,6 +213,7 @@ function GraaspTable<T>({
       },
       headerClass: DRAG_CELL_CLASS_NAME,
       width: DRAG_ICON_SIZE,
+      maxWidth: DRAG_COLUMN_WIDTH,
       sortable: false,
       headerName: '',
       flex: 0,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,8 +74,7 @@ export enum CCLicenseAdaption {
 
 export const DEFAULT_LOADER_SIZE = 20;
 
-export const DRAG_ICON_SIZE = 18;
-export const DRAG_COLUMN_WIDTH = 20;
+export const DRAG_COLUMN_WIDTH = 22;
 
 export const HEADER_USERNAME_MAX_WIDTH = 120;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -75,6 +75,7 @@ export enum CCLicenseAdaption {
 export const DEFAULT_LOADER_SIZE = 20;
 
 export const DRAG_ICON_SIZE = 18;
+export const DRAG_COLUMN_WIDTH = 20;
 
 export const HEADER_USERNAME_MAX_WIDTH = 120;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export * from './itemLogin';
 export { default as Card } from './Card';
 export { default as Thumbnail } from './Thumbnail';
 export { default as Avatar } from './Avatar';
+export { default as ItemBadges } from './ItemBadges';
 
 export * from './ItemFlag';
 


### PR DESCRIPTION
This PR adds a new component `ItemBadges` that displays hidden, published, public and pinned status of items.

This Component can be used on the Card component as seen below:
<img width="595" alt="Capture d’écran 2023-03-13 à 13 02 20" src="https://user-images.githubusercontent.com/39373170/225058615-7fe6276f-7d4d-4f74-86e2-e57616cc6330.png">

