### PR TITLE
fix: search bar can be compressed and is responsive

### DIFF
--- a/src/SearchInput/SearchInput.stories.tsx
+++ b/src/SearchInput/SearchInput.stories.tsx
@@ -21,3 +21,8 @@ const Template: ComponentStory<typeof SearchInput> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const MaxWidth = Template.bind({});
+MaxWidth.args = {
+  width: 300,
+};

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -20,13 +20,18 @@ export const SearchInput: FC<Props> = ({
   onChange,
   placeholder = 'Search…',
   value = '',
-  width = 400,
+  width,
 }) => {
   return (
     <Paper
       variant='outlined'
       component='form'
-      sx={{ display: 'flex', alignItems: 'center', width, minWidth: 100 }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        maxWidth: width,
+        minWidth: 0,
+      }}
     >
       <InputBase
         id={inputBaseId}


### PR DESCRIPTION
This PR updates the search bar to be able to compress (minWidth:0) and the 
`width` parameter can now be used to set a `maxWidth`. Otherwise he bar will always 
take the space available in its parent.

