### PR TITLE
fix: add collapsible and chat to itemstatus

### DIFF
--- a/src/ItemBadges/ItemBadges.stories.tsx
+++ b/src/ItemBadges/ItemBadges.stories.tsx
@@ -19,4 +19,6 @@ AllIcons.args = {
   isPinned: true,
   isPublished: true,
   isPublic: true,
+  isCollapsible: true,
+  showChatbox: true,
 };

--- a/src/ItemBadges/ItemBadges.tsx
+++ b/src/ItemBadges/ItemBadges.tsx
@@ -1,4 +1,10 @@
-import { Public, PushPin, VisibilityOff } from '@mui/icons-material';
+import {
+  Chat,
+  Public,
+  PushPin,
+  UnfoldLess,
+  VisibilityOff,
+} from '@mui/icons-material';
 import { Avatar, AvatarGroup, Tooltip } from '@mui/material';
 
 import React from 'react';
@@ -32,6 +38,10 @@ type Props = {
   isPublishedTooltip?: string;
   isPinned?: boolean;
   isPinnedTooltip?: string;
+  isCollapsible?: boolean;
+  isCollapsibleTooltip?: string;
+  showChatbox?: boolean;
+  showChatboxTooltip?: string;
   backgroundColor?: string;
 };
 
@@ -44,10 +54,14 @@ const ItemBadges = ({
   isPublishedTooltip = 'Published',
   isPublic = false,
   isPublicTooltip = 'Public',
+  isCollapsible = false,
+  isCollapsibleTooltip = 'Collapsible',
+  showChatbox = false,
+  showChatboxTooltip = 'Chat',
   backgroundColor = 'grey.600',
 }: Props): JSX.Element => {
   return (
-    <AvatarGroup>
+    <AvatarGroup max={10}>
       {isHidden && (
         <ItemBadge backgroundColor={backgroundColor} tooltip={isHiddenTooltip}>
           <VisibilityOff fontSize={ThumbnailSize.Small} />
@@ -73,6 +87,25 @@ const ItemBadges = ({
       {isPublic && (
         <ItemBadge backgroundColor={backgroundColor} tooltip={isPublicTooltip}>
           <Public fontSize={ThumbnailSize.Small} />
+        </ItemBadge>
+      )}
+      {isCollapsible && (
+        <ItemBadge
+          backgroundColor={backgroundColor}
+          tooltip={isCollapsibleTooltip}
+        >
+          <UnfoldLess fontSize={ThumbnailSize.Small} />
+        </ItemBadge>
+      )}
+      {showChatbox && (
+        <ItemBadge
+          backgroundColor={backgroundColor}
+          tooltip={showChatboxTooltip}
+        >
+          <Chat
+            fontSize={ThumbnailSize.Small}
+            sx={{ width: 15, height: 15, marginLeft: '1px', marginTop: '2px' }}
+          />
         </ItemBadge>
       )}
     </AvatarGroup>

--- a/src/ItemBadges/ItemBadges.tsx
+++ b/src/ItemBadges/ItemBadges.tsx
@@ -1,10 +1,8 @@
-import {
-  Chat,
-  Public,
-  PushPin,
-  UnfoldLess,
-  VisibilityOff,
-} from '@mui/icons-material';
+import Chat from '@mui/icons-material/Chat';
+import Public from '@mui/icons-material/Public';
+import PushPin from '@mui/icons-material/PushPin';
+import UnfoldLess from '@mui/icons-material/UnfoldLess';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { Avatar, AvatarGroup, Tooltip } from '@mui/material';
 
 import React from 'react';

--- a/src/buttons/CopyButton/CopyButton.tsx
+++ b/src/buttons/CopyButton/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { FilterNone } from '@mui/icons-material';
+import FilterNone from '@mui/icons-material/FilterNone';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import MenuItem from '@mui/material/MenuItem';

--- a/src/buttons/MoveButton/MoveButton.tsx
+++ b/src/buttons/MoveButton/MoveButton.tsx
@@ -1,4 +1,4 @@
-import { OpenWith } from '@mui/icons-material';
+import OpenWith from '@mui/icons-material/OpenWith';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import MenuItem from '@mui/material/MenuItem';


### PR DESCRIPTION
This PR adds the `isCollapsible` and `showCahtbox` statuses to the item badges.
<img width="347" alt="Capture d’écran 2023-03-30 à 12 01 51" src="https://user-images.githubusercontent.com/39373170/228801868-cfa3afda-6872-4001-bd50-8b2bb5ba978b.png">

closes #309 