### PR TITLE
fix: storybook deploy to pages

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -7,23 +7,44 @@ on:
     branches:
       - main
       - master
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
-    concurrency:
-      group: storybook-{{ github.ref }}
-      cancel-in-progress: true
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: install and build storybook files
-        run: |
-          yarn
-          yarn build-storybook
-      - name: deploy to github pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - uses: actions/checkout@v3
+
+      - name: Yarn Install and Cache
+        uses: graasp/graasp-deploy/.github/actions/yarn-install-and-cache@v1
+
+      - name: Build storybook
+        run: yarn build-storybook
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          folder: storybook-static # The folder that the build-storybook script generates files.
-          clean: true # delete files from your deployment destination that no longer exist in your deployment source
-          target-folder: docs
+          path: ./storybook-static
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This PR updates the deployement workflow to directly push github artifacts to GitHub Pages.

The `github-pages` branch will be deleted once this is merged. 

This should limit the noise on the repo.
