### PR TITLE
fix: add constraint for custom cell renderers

### DIFF
--- a/src/TableComponent/Table.tsx
+++ b/src/TableComponent/Table.tsx
@@ -84,6 +84,9 @@ const StyledDiv = styled('div')(({ theme }) => ({
     // reduce padding on left and right of cells
     padding: theme.spacing(0, 1),
   },
+  '.ag-cell-wrapper': {
+    minWidth: '0px',
+  },
 }));
 
 const ROW_CLASS_NAME = 'row-class-name';


### PR DESCRIPTION
This PR adds a style on the `.ag-cell-wrapper` to ensure that custom cell renderers do not overflow the width of the cell if they use flex containers.

Currently:
<img width="739" alt="Capture d’écran 2023-05-08 à 18 37 16" src="https://user-images.githubusercontent.com/39373170/236880329-f4243bac-d5ed-43e9-af58-af4c8f099aad.png">

With the fix:
<img width="735" alt="Capture d’écran 2023-05-08 à 18 37 52" src="https://user-images.githubusercontent.com/39373170/236880380-f44e9b14-e2b5-4d81-80cb-61df6d5cde86.png">
