### PR TITLE
362 add button role profile wrapper header

### DIFF
--- a/src/HeaderUserInformation/HeaderUserInformation.tsx
+++ b/src/HeaderUserInformation/HeaderUserInformation.tsx
@@ -75,7 +75,7 @@ const HeaderUserInformation: FC<HeaderUserInformationProps> = ({
       id={id}
       role={role}
       aria-haspopup={popUpType}
-      aria-controls={popUpId}
+      {...(popUpId ? { 'aria-controls': popUpId } : {})}
       aria-expanded={isPopUpOpen}
     >
       <Tooltip

--- a/src/HeaderUserInformation/HeaderUserInformation.tsx
+++ b/src/HeaderUserInformation/HeaderUserInformation.tsx
@@ -75,7 +75,7 @@ const HeaderUserInformation: FC<HeaderUserInformationProps> = ({
       id={id}
       role={role}
       aria-haspopup={popUpType}
-      {...(popUpId ? { 'aria-controls': popUpId } : {})}
+      aria-controls={popUpId}
       aria-expanded={isPopUpOpen}
     >
       <Tooltip

--- a/src/HeaderUserInformation/HeaderUserInformation.tsx
+++ b/src/HeaderUserInformation/HeaderUserInformation.tsx
@@ -36,8 +36,21 @@ export interface HeaderUserInformationProps {
   username: string;
   id?: UUID;
   isLoading?: boolean;
+  isPopUpOpen?: boolean;
   noUsernameMessage?: string;
   onClick?: MouseEventHandler<HTMLDivElement>;
+  popUpType?:
+    | boolean
+    | 'dialog'
+    | 'menu'
+    | 'grid'
+    | 'listbox'
+    | 'false'
+    | 'true'
+    | 'tree'
+    | undefined;
+  popUpId?: string;
+  role?: string;
 }
 
 const HeaderUserInformation: FC<HeaderUserInformationProps> = ({
@@ -47,6 +60,10 @@ const HeaderUserInformation: FC<HeaderUserInformationProps> = ({
   noUsernameMessage,
   onClick,
   username,
+  popUpType,
+  popUpId,
+  isPopUpOpen,
+  role,
 }) => {
   if (isLoading) {
     return (
@@ -62,7 +79,14 @@ const HeaderUserInformation: FC<HeaderUserInformationProps> = ({
   }
 
   return (
-    <WrapperDiv onClick={onClick} id={id}>
+    <WrapperDiv
+      onClick={onClick}
+      id={id}
+      role={role}
+      aria-haspopup={popUpType}
+      aria-controls={popUpId}
+      aria-expanded={isPopUpOpen}
+    >
       <Tooltip
         title={username || noUsernameMessage || 'You are not signed in.'}
       >

--- a/src/HeaderUserInformation/HeaderUserInformation.tsx
+++ b/src/HeaderUserInformation/HeaderUserInformation.tsx
@@ -4,7 +4,7 @@ import Skeleton from '@mui/material/Skeleton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
-import React, { FC, MouseEventHandler } from 'react';
+import React, { AriaAttributes, FC, MouseEventHandler } from 'react';
 
 import { UUID } from '@graasp/sdk';
 
@@ -39,16 +39,7 @@ export interface HeaderUserInformationProps {
   isPopUpOpen?: boolean;
   noUsernameMessage?: string;
   onClick?: MouseEventHandler<HTMLDivElement>;
-  popUpType?:
-    | boolean
-    | 'dialog'
-    | 'menu'
-    | 'grid'
-    | 'listbox'
-    | 'false'
-    | 'true'
-    | 'tree'
-    | undefined;
+  popUpType?: AriaAttributes['aria-haspopup'];
   popUpId?: string;
   role?: string;
 }

--- a/src/UserSwitch/UserSwitch.stories.tsx
+++ b/src/UserSwitch/UserSwitch.stories.tsx
@@ -4,20 +4,11 @@ import React from 'react';
 
 import Avatar from '../Avatar/Avatar';
 import { MOCK_MEMBER_RECORD } from '../utils/fixtures';
-import { TABLE_CATEGORIES } from '../utils/storybook';
 import UserSwitch from './UserSwitch';
 
 const meta: Meta<typeof UserSwitch> = {
   title: 'Common/UserSwitch',
   component: UserSwitch,
-
-  argTypes: {
-    id: {
-      table: {
-        category: TABLE_CATEGORIES.SELECTORS,
-      },
-    },
-  },
 };
 
 export default meta;

--- a/src/UserSwitch/UserSwitch.stories.tsx
+++ b/src/UserSwitch/UserSwitch.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import React from 'react';
+
 import Avatar from '../Avatar/Avatar';
 import { MOCK_MEMBER } from '../utils/fixtures';
 import { TABLE_CATEGORIES } from '../utils/storybook';

--- a/src/UserSwitch/UserSwitch.stories.tsx
+++ b/src/UserSwitch/UserSwitch.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import Avatar from '../Avatar/Avatar';
-import { MOCK_MEMBER } from '../utils/fixtures';
+import { MOCK_MEMBER_RECORD } from '../utils/fixtures';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import UserSwitch from './UserSwitch';
 
@@ -26,11 +26,11 @@ type Story = StoryObj<typeof UserSwitch>;
 
 export const SignedIn: Story = {
   args: {
-    member: MOCK_MEMBER,
+    member: MOCK_MEMBER_RECORD,
     renderAvatar: () => (
       <Avatar
         url={'https://picsum.photos/100'}
-        alt={`profile image ${MOCK_MEMBER?.name}`}
+        alt={`profile image ${MOCK_MEMBER_RECORD?.name}`}
         component={'avatar'}
         sx={{ mx: 1 }}
       />

--- a/src/UserSwitch/UserSwitch.stories.tsx
+++ b/src/UserSwitch/UserSwitch.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Avatar from '../Avatar/Avatar';
+import { MOCK_MEMBER } from '../utils/fixtures';
+import { TABLE_CATEGORIES } from '../utils/storybook';
+import UserSwitch from './UserSwitch';
+
+const meta: Meta<typeof UserSwitch> = {
+  title: 'Common/UserSwitch',
+  component: UserSwitch,
+
+  argTypes: {
+    id: {
+      table: {
+        category: TABLE_CATEGORIES.SELECTORS,
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UserSwitch>;
+
+export const SignedIn: Story = {
+  args: {
+    member: MOCK_MEMBER,
+    renderAvatar: () => (
+      <Avatar
+        url={'https://picsum.photos/100'}
+        alt={`profile image ${MOCK_MEMBER?.name}`}
+        component={'avatar'}
+        sx={{ mx: 1 }}
+      />
+    ),
+  },
+};

--- a/src/UserSwitch/UserSwitch.tsx
+++ b/src/UserSwitch/UserSwitch.tsx
@@ -42,6 +42,7 @@ interface Props {
   isMemberLoading?: boolean;
   member?: MemberRecord;
   members?: List<MemberRecord>;
+  menuId?: string;
   onMemberClick?: (_id: string) => MouseEventHandler;
   onSeeProfileClick?: MouseEventHandler;
   renderAvatar?: (member?: MemberRecord) => JSX.Element;
@@ -56,6 +57,7 @@ const UserSwitch: FC<Props> = ({
   buttonId,
   isMemberLoading = false,
   member,
+  menuId,
   onSeeProfileClick,
   renderAvatar = () => <></>,
   seeProfileButtonId,
@@ -199,10 +201,19 @@ const UserSwitch: FC<Props> = ({
 
   return (
     <>
-      <StyledWrapper onClick={handleClick} id={buttonId}>
+      <StyledWrapper
+        onClick={handleClick}
+        id={buttonId}
+        role='button'
+        aria-haspopup={'menu'}
+        aria-controls={menuId}
+        aria-expanded={Boolean(anchorEl)}
+        tabIndex={0}
+      >
         {renderButtonContent()}
       </StyledWrapper>
       <Menu
+        id={menuId}
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}

--- a/src/utils/fixtures.ts
+++ b/src/utils/fixtures.ts
@@ -1,7 +1,7 @@
-import { MemberType } from '@graasp/sdk';
+import { Member, MemberType, convertJs } from '@graasp/sdk';
 import { MemberRecord } from '@graasp/sdk/frontend';
 
-export const MOCK_MEMBER = {
+export const MOCK_MEMBER: Member = {
   id: 'id',
   name: 'creator',
   email: 'email',
@@ -11,12 +11,4 @@ export const MOCK_MEMBER = {
   type: MemberType.Individual,
 };
 
-export const MOCK_MEMBER_RECORD = {
-  id: 'id',
-  name: 'creator',
-  email: 'email',
-  extra: {},
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  type: MemberType.Individual,
-} as MemberRecord;
+export const MOCK_MEMBER_RECORD: MemberRecord = convertJs(MOCK_MEMBER);

--- a/src/utils/fixtures.ts
+++ b/src/utils/fixtures.ts
@@ -1,4 +1,5 @@
 import { MemberType } from '@graasp/sdk';
+import { MemberRecord } from '@graasp/sdk/frontend';
 
 export const MOCK_MEMBER = {
   id: 'id',
@@ -9,3 +10,13 @@ export const MOCK_MEMBER = {
   updatedAt: new Date(),
   type: MemberType.Individual,
 };
+
+export const MOCK_MEMBER_RECORD = {
+  id: 'id',
+  name: 'creator',
+  email: 'email',
+  extra: {},
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  type: MemberType.Individual,
+} as MemberRecord;


### PR DESCRIPTION
Closes #362 

Adds role button to the profile wrapper working as a button in the `UserSwitch`. As well as aria-attributes used for pop-up menus. 

Also adds this to `HeaderUserInformation` so this could be used in `UserSwitch` later (I didn't do it now since I can't test so everything works as it should in Builder etc). 

I've added a mock user of memberRecord type, however I don't know if this should be in fixtures. I didn't add any argTypes to the story, since I don't know what they should be. 

Could also be an idea to set an aria-hidden on the tooltip when the text for it is the username, since otherwise the username is read out twice by screen readers. However this would also hide the profile image from the accessibility tree, so it's a bit of a trade off.