### PR TITLE
fix(deps): revert react-quill to 2.0.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "qs": "6.11.2",
     "quill-emoji": "0.2.0",
     "react-cookie-consent": "7.4.1",
-    "react-quill": "2.0.0",
+    "react-quill": "2.0.0-beta.4",
     "react-rnd": "10.4.1",
     "react-text-mask": "5.5.0",
     "uuid": "9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2262,7 +2262,7 @@ __metadata:
     react-dom: 17.0.2
     react-i18next: 11.18.6
     react-query: 3.39.3
-    react-quill: 2.0.0
+    react-quill: 2.0.0-beta.4
     react-rnd: 10.4.1
     react-router-dom: 6.11.2
     react-test-renderer: 18.2.0
@@ -14745,17 +14745,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-quill@npm:2.0.0":
-  version: 2.0.0
-  resolution: "react-quill@npm:2.0.0"
+"react-quill@npm:2.0.0-beta.4":
+  version: 2.0.0-beta.4
+  resolution: "react-quill@npm:2.0.0-beta.4"
   dependencies:
     "@types/quill": ^1.3.10
     lodash: ^4.17.4
     quill: ^1.3.7
   peerDependencies:
-    react: ^16 || ^17 || ^18
-    react-dom: ^16 || ^17 || ^18
-  checksum: 568e28656ae3a40944d5c4cc9d35accc21834cf15b61a74af4566d8772eb152ce65c0d5ea6da65918cb5c9453c1a2041c60c4a19819bf319bee2e067b613d32b
+    react: ^16 || ^17
+    react-dom: ^16 || ^17
+  checksum: bec76caae579d199d47b475af2236321c902dd468bd9b6a688c6bc1b4c8ddcf8407348ae3a490f9e45b6e33dc7d0fffe026ccd595297440c2623964d5f466c29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Linked to graasp/graasp-builder#660

closes #369 