### PR TITLE
fix(a11y): use item name when alttext is falsy

### DIFF
--- a/src/items/FileItem.tsx
+++ b/src/items/FileItem.tsx
@@ -117,12 +117,14 @@ const FileItem: FC<FileItemProps> = ({
     const {
       mimetype,
       name: originalFileName,
-      altText = item.name,
+      altText,
     } = { ...fileExtra?.toJS(), ...s3FileExtra?.toJS() };
 
     if (mimetype) {
       if (MimeTypes.isImage(mimetype)) {
-        return <FileImage id={id} url={url} alt={altText} sx={sx} />;
+        return (
+          <FileImage id={id} url={url} alt={altText || item.name} sx={sx} />
+        );
       } else if (MimeTypes.isAudio(mimetype)) {
         return <FileAudio id={id} url={url} type={mimetype} sx={sx} />;
       } else if (MimeTypes.isVideo(mimetype)) {


### PR DESCRIPTION
The `altText` should default to the item name when it is `undefined` or `''`. This is not the best but at least assistive technologies will not skip it.