### PR TITLE
fix: replace `output` by `fileName` in rollup-plugin-scss options

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default {
       exclude: ['**/*.test.ts', '**/*.test.tsx', '**/*.stories.tsx'],
     }),
     commonjs(),
-    scss({ outputStyle: 'compressed', output: 'dist/bundle.css' }),
+    scss({ outputStyle: 'compressed', fileName: 'bundle.css' }),
     babel({ babelHelpers: 'bundled' }),
     // import katex fonts
     copy({


### PR DESCRIPTION
This PR fixes an issue in the latest release.

The `bundle.css` was not emmited because of the update of the `rollup-plugin-scss` dependency.

This fixes this issue and the bundle.css is not succesfully emitted.
