### PR TITLE
fix: show sign out in user switch

### DIFF
--- a/src/UserSwitch/UserSwitchWrapper.stories.tsx
+++ b/src/UserSwitch/UserSwitchWrapper.stories.tsx
@@ -6,21 +6,22 @@ import React from 'react';
 
 import Avatar from '../Avatar/Avatar';
 import { MOCK_MEMBER_RECORD } from '../utils/fixtures';
-import UserSwitch from './UserSwitch';
+import UserSwitchWrapper from './UserSwitchWrapper';
 
-const meta: Meta<typeof UserSwitch> = {
-  title: 'Common/UserSwitch/UserSwitch',
-  component: UserSwitch,
+const meta: Meta<typeof UserSwitchWrapper> = {
+  title: 'Common/UserSwitch/UserSwitchWrapper',
+  component: UserSwitchWrapper,
 };
 
 export default meta;
 
-type Story = StoryObj<typeof UserSwitch>;
+type Story = StoryObj<typeof UserSwitchWrapper>;
 
 export const SignedIn: Story = {
   args: {
-    member: MOCK_MEMBER_RECORD,
+    currentMember: MOCK_MEMBER_RECORD,
     seeProfileText: 'See Profile',
+    signOutText: 'Sign Out',
     renderAvatar: () => (
       <Avatar
         url={'https://picsum.photos/100'}
@@ -31,7 +32,6 @@ export const SignedIn: Story = {
     ),
   },
 };
-
 SignedIn.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
 
@@ -39,18 +39,24 @@ SignedIn.play = async ({ canvasElement }) => {
   const nameText = canvas.getByLabelText(MOCK_MEMBER_RECORD.name);
   await userEvent.click(nameText);
 
-  // profile button
   const menuCanvas = within(await screen.getByRole('menu'));
+
+  // profile button
   const profileButton = menuCanvas.getByText(SignedIn.args!.seeProfileText!);
   expect(profileButton).toBeInTheDocument();
 
   // email
   const emailText = menuCanvas.getByText(MOCK_MEMBER_RECORD.email);
   expect(emailText).toBeInTheDocument();
+
+  // sign out button
+  const signOutButton = menuCanvas.getByText(SignedIn.args!.signOutText!);
+  expect(signOutButton).toBeInTheDocument();
 };
 
 export const SignedOut: Story = {
   args: {
+    switchMemberText: 'Sign In',
     renderAvatar: () => (
       <Avatar
         url={'https://picsum.photos/100'}
@@ -59,7 +65,6 @@ export const SignedOut: Story = {
         sx={{ mx: 1 }}
       />
     ),
-    Actions: [<h3>some content</h3>],
   },
 };
 
@@ -72,6 +77,6 @@ SignedOut.play = async ({ canvasElement }) => {
 
   // custom content
   const menuCanvas = within(await screen.getByRole('menu'));
-  const profileButton = menuCanvas.getByText('some content');
-  expect(profileButton).toBeInTheDocument();
+  const signInButton = menuCanvas.getByText(SignedOut.args!.switchMemberText!);
+  expect(signInButton).toBeInTheDocument();
 };

--- a/src/UserSwitch/UserSwitchWrapper.tsx
+++ b/src/UserSwitch/UserSwitchWrapper.tsx
@@ -1,3 +1,4 @@
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
 import { Divider } from '@mui/material';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -5,10 +6,9 @@ import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 
 import React, { FC } from 'react';
-import type { UseQueryResult } from 'react-query';
 
-import { Member, redirect } from '@graasp/sdk';
-import { MemberRecord, ResultOfRecord } from '@graasp/sdk/frontend';
+import { redirect } from '@graasp/sdk';
+import { MemberRecord } from '@graasp/sdk/frontend';
 
 import Loader from '../Loader';
 import UserSwitch from './UserSwitch';
@@ -20,9 +20,9 @@ interface Props {
   ButtonContent?: JSX.Element;
   buttonId?: string;
   currentMember?: MemberRecord;
-  domain: string;
+  // domain: string;
   isCurrentMemberLoading: boolean;
-  isCurrentMemberSuccess: boolean;
+  // isCurrentMemberSuccess: boolean;
   profilePath: string;
   redirectPath: string;
   renderAvatar: (member?: MemberRecord) => JSX.Element;
@@ -34,8 +34,8 @@ interface Props {
   signOutMenuItemId?: string;
   signOutText?: string;
   // switchMember: (args: { memberId: string; domain: string }) => Promise<void>;
-  // switchMemberText?: string;
-  useMembers: (ids: string[]) => UseQueryResult<ResultOfRecord<Member>>;
+  switchMemberText?: string;
+  // useMembers: (ids: string[]) => UseQueryResult<ResultOfRecord<Member>>;
 }
 
 const UserSwitchWrapper: FC<Props> = ({
@@ -52,12 +52,12 @@ const UserSwitchWrapper: FC<Props> = ({
   seeProfileButtonId,
   seeProfileText = 'See Profile',
   signedOutTooltipText = 'You are not signed in.',
-  // signInMenuItemId,
+  signInMenuItemId,
   signOut,
   signOutMenuItemId,
   signOutText = 'Sign Out',
   // switchMember,
-  // switchMemberText = 'Sign in with another account',
+  switchMemberText = 'Sign in',
   // useMembers,
 }) => {
   // get stored sessions
@@ -91,11 +91,11 @@ const UserSwitchWrapper: FC<Props> = ({
     redirect(redirectPath);
   };
 
-  // const handleSignIn = (): void => {
-  //   setCurrentSession(null, domain);
-  //   saveUrlForRedirection(window.location.href, domain);
-  //   return redirect(redirectPath);
-  // };
+  const handleSignIn = (): void => {
+    // setCurrentSession(null, domain);
+    // saveUrlForRedirection(window.location.href, domain);
+    return redirect(redirectPath);
+  };
 
   const goToProfile = (): void => {
     redirect(profilePath);
@@ -104,25 +104,26 @@ const UserSwitchWrapper: FC<Props> = ({
   // const onMemberClick = (memberId: string) => () =>
   //   switchMember({ memberId, domain });
 
-  let Actions: JSX.Element[] = [
-    // <MenuItem key='signin' onClick={handleSignIn} id={signInMenuItemId}>
-    //   <ListItemIcon>
-    //     <AccountCircleIcon fontSize='large' />
-    //   </ListItemIcon>
-    //   <Typography variant='subtitle2'>{switchMemberText}</Typography>
-    // </MenuItem>,
-  ];
+  let Actions: JSX.Element[];
 
   if (currentMember && currentMember.id) {
-    Actions = Actions.concat([
-      <Divider key='divider' />,
+    Actions = [
       <MenuItem key='signout' onClick={handleSignOut} id={signOutMenuItemId}>
         <ListItemIcon>
           <MeetingRoomIcon fontSize='large' />
         </ListItemIcon>
         <Typography variant='subtitle2'>{signOutText}</Typography>
       </MenuItem>,
-    ]);
+    ];
+  } else {
+    Actions = [
+      <MenuItem key='signin' onClick={handleSignIn} id={signInMenuItemId}>
+        <ListItemIcon>
+          <AccountCircleIcon fontSize='large' />
+        </ListItemIcon>
+        <Typography variant='subtitle2'>{switchMemberText}</Typography>
+      </MenuItem>,
+    ];
   }
 
   return (

--- a/src/UserSwitch/UserSwitchWrapper.tsx
+++ b/src/UserSwitch/UserSwitchWrapper.tsx
@@ -1,6 +1,5 @@
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
-import { Divider } from '@mui/material';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';


### PR DESCRIPTION
I've enabled back the "sign out" menu item that was missing. 
I've added some simple visual tests for `UserSwitch` and `UserSwitchWrapper`.

close #440 