### PR TITLE
fix: zIndex on quill tooltip

### DIFF
--- a/src/TextEditor/TextEditor.tsx
+++ b/src/TextEditor/TextEditor.tsx
@@ -64,38 +64,35 @@ export type TextEditorProps = {
   value?: string;
 };
 
-const Div = styled('div')(
-  ({
-    edit,
-    maxHeight,
-    styles,
-  }: {
-    edit?: boolean;
-    maxHeight?: number | string;
-    styles?: React.CSSProperties;
-  }) => ({
-    '& .ql-editor': {
-      // adapt height if read only
-      minHeight: !edit ? 0 : TEXT_EDITOR_MIN_HEIGHT,
-      // necessary styles to avoid window scrolling top on paste
-      // set a max height only on edition
-      maxHeight: edit ? maxHeight ?? TEXT_EDITOR_MAX_HEIGHT : '100%',
-      overflow: 'auto',
+const Div = styled('div')<{
+  edit?: boolean;
+  maxHeight?: number | string;
+  styles?: React.CSSProperties;
+}>(({ theme, edit, maxHeight, styles }) => ({
+  '.ql-tooltip': {
+    zIndex: theme.zIndex.tooltip,
+  },
+  '& .ql-editor': {
+    // adapt height if read only
+    minHeight: !edit ? 0 : TEXT_EDITOR_MIN_HEIGHT,
+    // necessary styles to avoid window scrolling top on paste
+    // set a max height only on edition
+    maxHeight: edit ? maxHeight ?? TEXT_EDITOR_MAX_HEIGHT : '100%',
+    overflow: 'auto',
 
-      '& p': {
-        paddingBottom: 3,
-        paddingTop: 3,
-      },
+    '& p': {
+      paddingBottom: 3,
+      paddingTop: 3,
+    },
 
-      ...styles,
-    },
-    '& .ql-container': {
-      border: !edit ? 'none !important' : undefined,
-      // use font size from mui theme
-      fontSize: 'unset',
-    },
-  }),
-);
+    ...styles,
+  },
+  '& .ql-container': {
+    border: !edit ? 'none !important' : undefined,
+    // use font size from mui theme
+    fontSize: 'unset',
+  },
+}));
 
 const TextEditor = ({
   cancelButtonId,


### PR DESCRIPTION
In this PR we fix an issue related to the `z-index` property on the elements in the Quill Text Editor.

### Issue:
When opening the link tool, the popup that appears is **under** the "Cancel" and "Save" buttons. 

### Solution:
Set a `z-index` higher than the z-index of the buttons. We can use [the z-index from MUI](https://mui.com/material-ui/customization/z-index/) and select a suitable value like `tooltip`. 

<img width="942" alt="Screenshot 2023-07-27 at 19 09 55" src="https://github.com/graasp/graasp-ui/assets/39373170/2f8ad91f-e4c9-464d-88c8-485acafb99a7">
