### PR TITLE
feat: add ThemeContext with rtl support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "uuid": "9.0.0"
   },
   "peerDependencies": {
+    "@emotion/cache": "~11.10.7",
     "@emotion/react": "~11.10.6 || ~11.11.0",
     "@emotion/styled": "~11.10.6 || ~11.11.0",
     "@mui/icons-material": "~5.11.9 || ~5.13.0 || ~5.14.0",
@@ -76,7 +77,9 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^12.2.0",
-    "react-router-dom": "^6.11.0"
+    "react-router-dom": "^6.11.0",
+    "stylis": "^4.1.3",
+    "stylis-plugin-rtl": "^2.1.1"
   },
   "peerDependenciesMeta": {
     "ag-grid-community": {
@@ -94,6 +97,7 @@
     "@babel/preset-typescript": "^7.21.5",
     "@commitlint/cli": "17.6.7",
     "@commitlint/config-conventional": "17.6.7",
+    "@emotion/cache": "~11.10.7",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@mdx-js/react": "2.3.0",
@@ -129,6 +133,7 @@
     "@types/react-dom": "18.2.7",
     "@types/react-router-dom": "5.3.3",
     "@types/react-text-mask": "5.4.11",
+    "@types/stylis": "4.2.0",
     "@types/uuid": "9.0.2",
     "@typescript-eslint/eslint-plugin": "6.2.0",
     "@typescript-eslint/parser": "6.2.0",
@@ -166,6 +171,8 @@
     "rollup-plugin-scss": "4.0.0",
     "sass": "1.64.1",
     "storybook": "7.2.1",
+    "stylis": "^4.1.3",
+    "stylis-plugin-rtl": "^2.1.1",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "5.1.6",

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -17,6 +17,7 @@ type Props<T> = {
   sx?: SxProps;
   values: { value: T; text: string }[];
   variant?: MuiSelectProps['variant'];
+  size?: MuiSelectProps['size'];
 };
 
 function Select<T extends string | number | readonly string[] | undefined>({
@@ -32,10 +33,11 @@ function Select<T extends string | number | readonly string[] | undefined>({
   sx,
   values,
   variant,
+  size,
 }: Props<T>): JSX.Element {
   const showLabel = Boolean(labelId ?? label);
   return (
-    <FormControl sx={{ mt: 1 }}>
+    <FormControl sx={{ mt: 1 }} size={size}>
       {showLabel && <InputLabel id={labelId}>{label}</InputLabel>}
       <MuiSelect
         labelId={labelId}

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -13,7 +13,7 @@ type Props<T> = {
   id?: string;
   label?: MuiSelectProps['label'];
   labelId?: MuiSelectProps['labelId'];
-  onChange?: MuiSelectProps['onChange'];
+  onChange?: MuiSelectProps<T>['onChange'];
   sx?: SxProps;
   values: { value: T; text: string }[];
   variant?: MuiSelectProps['variant'];

--- a/src/ThemeContext/LanguageSelect.tsx
+++ b/src/ThemeContext/LanguageSelect.tsx
@@ -1,0 +1,46 @@
+import { Direction, SelectChangeEvent, SxProps } from '@mui/material';
+
+import React, { Dispatch, useState } from 'react';
+
+import Select from '../Select';
+import { I18nInstance } from '../types';
+
+const LanguageSelect = ({
+  i18n,
+  setDirection,
+  languageSelectSx,
+  langs,
+  languageSelectLabel,
+}: {
+  i18n: I18nInstance;
+  setDirection?: Dispatch<Direction>;
+  languageSelectSx?: SxProps;
+  langs: { [key: string]: string };
+  languageSelectLabel?: string;
+}): JSX.Element => {
+  // init local lang, it does not update if we use i18n language directly
+  const [lang, setLang] = useState(i18n.language);
+
+  const handleLangSelect = (event: SelectChangeEvent<string>): void => {
+    const d = i18n.dir(event.target.value);
+    document.dir = d;
+    setDirection?.(d);
+    i18n.changeLanguage(event.target.value);
+    setLang(event.target.value);
+  };
+
+  const label = languageSelectLabel ?? 'Language';
+
+  return (
+    <Select
+      label={label}
+      labelId='language-select-label'
+      defaultValue={lang}
+      sx={languageSelectSx}
+      onChange={handleLangSelect}
+      values={Object.entries(langs).map(([k, l]) => ({ value: k, text: l }))}
+    />
+  );
+};
+
+export default LanguageSelect;

--- a/src/ThemeContext/LanguageSelect.tsx
+++ b/src/ThemeContext/LanguageSelect.tsx
@@ -11,15 +11,17 @@ const LanguageSelect = ({
   setDirection,
   languageSelectSx,
   langs,
-  languageSelectLabel = 'Language',
+  label = 'Language',
+  size,
   variant,
 }: {
   i18n: I18nInstance;
   setDirection?: Dispatch<Direction>;
   languageSelectSx?: SxProps;
   langs: { [key: string]: string };
-  languageSelectLabel?: string | null;
+  label?: string | null;
   variant?: MuiSelectProps['variant'];
+  size?: MuiSelectProps['size'];
 }): JSX.Element => {
   // init local lang, it does not update if we use i18n language directly
   const [lang, setLang] = useState(i18n.language);
@@ -34,9 +36,10 @@ const LanguageSelect = ({
 
   return (
     <Select
-      label={languageSelectLabel}
+      size={size}
+      label={label}
       variant={variant}
-      labelId={languageSelectLabel ? 'language-select-label' : undefined}
+      labelId={label ? 'language-select-label' : undefined}
       defaultValue={lang}
       sx={{ minWidth: 80, ...languageSelectSx }}
       onChange={handleLangSelect}

--- a/src/ThemeContext/LanguageSelect.tsx
+++ b/src/ThemeContext/LanguageSelect.tsx
@@ -38,6 +38,7 @@ const LanguageSelect = ({
       defaultValue={lang}
       sx={languageSelectSx}
       onChange={handleLangSelect}
+      buildOptionId={value=>`language-${value}`}
       values={Object.entries(langs).map(([k, l]) => ({ value: k, text: l }))}
     />
   );

--- a/src/ThemeContext/LanguageSelect.tsx
+++ b/src/ThemeContext/LanguageSelect.tsx
@@ -1,4 +1,5 @@
 import { Direction, SelectChangeEvent, SxProps } from '@mui/material';
+import { SelectProps as MuiSelectProps } from '@mui/material/Select';
 
 import React, { Dispatch, useState } from 'react';
 
@@ -10,13 +11,15 @@ const LanguageSelect = ({
   setDirection,
   languageSelectSx,
   langs,
-  languageSelectLabel,
+  languageSelectLabel = 'Language',
+  variant,
 }: {
   i18n: I18nInstance;
   setDirection?: Dispatch<Direction>;
   languageSelectSx?: SxProps;
   langs: { [key: string]: string };
-  languageSelectLabel?: string;
+  languageSelectLabel?: string | null;
+  variant?: MuiSelectProps['variant'];
 }): JSX.Element => {
   // init local lang, it does not update if we use i18n language directly
   const [lang, setLang] = useState(i18n.language);
@@ -29,16 +32,15 @@ const LanguageSelect = ({
     setLang(event.target.value);
   };
 
-  const label = languageSelectLabel ?? 'Language';
-
   return (
     <Select
-      label={label}
-      labelId='language-select-label'
+      label={languageSelectLabel}
+      variant={variant}
+      labelId={languageSelectLabel ? 'language-select-label' : undefined}
       defaultValue={lang}
-      sx={languageSelectSx}
+      sx={{ minWidth: 80, ...languageSelectSx }}
       onChange={handleLangSelect}
-      buildOptionId={value=>`language-${value}`}
+      buildOptionId={(value) => `language-${value}`}
       values={Object.entries(langs).map(([k, l]) => ({ value: k, text: l }))}
     />
   );

--- a/src/ThemeContext/ThemeContext.stories.tsx
+++ b/src/ThemeContext/ThemeContext.stories.tsx
@@ -33,8 +33,20 @@ const i18n = {
   },
 };
 
-export const Simple: Story = {
+export const Default: Story = {
   args: {
+    children: <Child />,
+    i18n,
+    langs: {
+      en: 'English',
+      ar: 'Arabic',
+    },
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    languageSelectLabel: null,
     children: <Child />,
     i18n,
     langs: {

--- a/src/ThemeContext/ThemeContext.stories.tsx
+++ b/src/ThemeContext/ThemeContext.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import React from 'react';
+
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+const Child = (): JSX.Element => {
+  const { languageSelect } = useTheme();
+  return languageSelect;
+};
+
+const meta: Meta<typeof ThemeProvider> = {
+  title: 'Context/Theme',
+  component: ThemeProvider,
+  argTypes: {},
+};
+export default meta;
+
+type Story = StoryObj<typeof ThemeProvider>;
+
+// hack to actually change a mock i18n
+const i18n = {
+  language: 'en',
+  t: (s: string) => s,
+  dir: (l: string) => {
+    if (l === 'ar') {
+      return 'rtl';
+    }
+    return 'ltr';
+  },
+  changeLanguage: (lang: string) => {
+    i18n.language = lang;
+  },
+};
+
+export const Simple: Story = {
+  args: {
+    children: <Child />,
+    i18n,
+    langs: {
+      en: 'English',
+      ar: 'Arabic',
+    },
+  },
+};

--- a/src/ThemeContext/ThemeContext.tsx
+++ b/src/ThemeContext/ThemeContext.tsx
@@ -1,0 +1,75 @@
+import createCache from '@emotion/cache';
+import { CacheProvider, EmotionCache } from '@emotion/react';
+import { prefixer } from 'stylis';
+import rtlPlugin from 'stylis-plugin-rtl';
+
+import { Direction, SxProps } from '@mui/material';
+import { ThemeProvider as MuiThemeProvider } from '@mui/material';
+
+import React, { useContext, useMemo } from 'react';
+import { createContext, useState } from 'react';
+
+import { theme } from '../theme';
+import { I18nInstance } from '../types';
+import LanguageSelect from './LanguageSelect';
+
+type Props = {
+  children: JSX.Element | JSX.Element[];
+  i18n: I18nInstance;
+  langs: { [key: string]: string };
+  languageSelectSx: SxProps;
+  languageSelectLabel?: string;
+};
+
+type Context = {
+  languageSelect: JSX.Element;
+  direction: Direction;
+};
+
+const ThemeContext = createContext<Context>({
+  languageSelect: <></>,
+  direction: 'ltr',
+});
+
+const getCacheForDirection = (direction?: Direction): EmotionCache =>
+  createCache({
+    key: `mui-dir-${direction}`,
+    stylisPlugins: [prefixer, ...(direction === 'rtl' ? [rtlPlugin] : [])],
+  });
+
+const ThemeProvider = ({
+  children,
+  i18n,
+  langs,
+  languageSelectSx,
+  languageSelectLabel,
+}: Props): JSX.Element => {
+  const [direction, setDirection] = useState<Direction>(theme.direction);
+  const languageSelect = (
+    <LanguageSelect
+      languageSelectSx={languageSelectSx}
+      i18n={i18n}
+      setDirection={setDirection}
+      langs={langs}
+      languageSelectLabel={languageSelectLabel}
+    />
+  );
+  const value = useMemo(
+    () => ({ direction, languageSelect }),
+    [direction, languageSelect],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <MuiThemeProvider theme={{ ...theme, direction }}>
+        <CacheProvider value={getCacheForDirection(direction)}>
+          {children}
+        </CacheProvider>
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+const useTheme = (): Context => useContext(ThemeContext);
+
+export { ThemeProvider, useTheme };

--- a/src/ThemeContext/ThemeContext.tsx
+++ b/src/ThemeContext/ThemeContext.tsx
@@ -21,6 +21,7 @@ type Props = {
   languageSelectSx: SxProps;
   languageSelectLabel?: string | null;
   languageSelectVariant?: MuiSelectProps['variant'];
+  languageSelectSize?: MuiSelectProps['size'];
 };
 
 type Context = {
@@ -45,7 +46,8 @@ const ThemeProvider = ({
   langs,
   languageSelectSx,
   languageSelectLabel,
-  languageSelectVariant = 'standard',
+  languageSelectVariant = 'outlined',
+  languageSelectSize = 'small',
 }: Props): JSX.Element => {
   const [direction, setDirection] = useState<Direction>(theme.direction);
   const languageSelect = (
@@ -55,7 +57,8 @@ const ThemeProvider = ({
       setDirection={setDirection}
       langs={langs}
       variant={languageSelectVariant}
-      languageSelectLabel={languageSelectLabel}
+      label={languageSelectLabel}
+      size={languageSelectSize}
     />
   );
   const value = useMemo(

--- a/src/ThemeContext/ThemeContext.tsx
+++ b/src/ThemeContext/ThemeContext.tsx
@@ -5,6 +5,7 @@ import rtlPlugin from 'stylis-plugin-rtl';
 
 import { Direction, SxProps } from '@mui/material';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
+import { SelectProps as MuiSelectProps } from '@mui/material/Select';
 
 import React, { useContext, useMemo } from 'react';
 import { createContext, useState } from 'react';
@@ -18,7 +19,8 @@ type Props = {
   i18n: I18nInstance;
   langs: { [key: string]: string };
   languageSelectSx: SxProps;
-  languageSelectLabel?: string;
+  languageSelectLabel?: string | null;
+  languageSelectVariant?: MuiSelectProps['variant'];
 };
 
 type Context = {
@@ -43,6 +45,7 @@ const ThemeProvider = ({
   langs,
   languageSelectSx,
   languageSelectLabel,
+  languageSelectVariant = 'standard',
 }: Props): JSX.Element => {
   const [direction, setDirection] = useState<Direction>(theme.direction);
   const languageSelect = (
@@ -51,6 +54,7 @@ const ThemeProvider = ({
       i18n={i18n}
       setDirection={setDirection}
       langs={langs}
+      variant={languageSelectVariant}
       languageSelectLabel={languageSelectLabel}
     />
   );

--- a/src/ThemeContext/index.ts
+++ b/src/ThemeContext/index.ts
@@ -1,0 +1,2 @@
+export * from './ThemeContext';
+export * from './LanguageSelect';

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,4 +71,6 @@ export * from './Select';
 export { default as PlatformSwitch } from './PlatformSwitch';
 export * from './PlatformSwitch';
 
+export * from './ThemeContext';
+
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Direction } from '@mui/material';
+
 export enum Variant {
   TEXT = 'text',
   RECT = 'rectangular',
@@ -34,3 +36,10 @@ export enum CCSharing {
 }
 
 export type CCSharingVariant = CCSharing | `${CCSharing}`;
+
+export type I18nInstance = {
+  language: string;
+  t: (s: string) => string;
+  dir: (l: string) => Direction;
+  changeLanguage: (lang: string) => void;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,6 +3105,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/cache@npm:~11.10.7":
+  version: 11.10.8
+  resolution: "@emotion/cache@npm:11.10.8"
+  dependencies:
+    "@emotion/memoize": ^0.8.0
+    "@emotion/sheet": ^1.2.1
+    "@emotion/utils": ^1.2.0
+    "@emotion/weak-memoize": ^0.3.0
+    stylis: 4.1.4
+  checksum: a67751db54077813ee3a011f255ee5c79eb375284cec8404866d44da904d69b037566047ca52549772b8038f8cd00ebd092c628ddc764fe89d6932c16afd71e3
+  languageName: node
+  linkType: hard
+
 "@emotion/hash@npm:^0.9.1":
   version: 0.9.1
   resolution: "@emotion/hash@npm:0.9.1"
@@ -3121,7 +3134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/memoize@npm:^0.8.1":
+"@emotion/memoize@npm:^0.8.0, @emotion/memoize@npm:^0.8.1":
   version: 0.8.1
   resolution: "@emotion/memoize@npm:0.8.1"
   checksum: a19cc01a29fcc97514948eaab4dc34d8272e934466ed87c07f157887406bc318000c69ae6f813a9001c6a225364df04249842a50e692ef7a9873335fbcc141b0
@@ -3162,7 +3175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/sheet@npm:^1.2.2":
+"@emotion/sheet@npm:^1.2.1, @emotion/sheet@npm:^1.2.2":
   version: 1.2.2
   resolution: "@emotion/sheet@npm:1.2.2"
   checksum: d973273c9c15f1c291ca2269728bf044bd3e92a67bca87943fa9ec6c3cd2b034f9a6bfe95ef1b5d983351d128c75b547b43ff196a00a3875f7e1d269793cecfe
@@ -3205,14 +3218,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.2.1":
+"@emotion/utils@npm:^1.2.0, @emotion/utils@npm:^1.2.1":
   version: 1.2.1
   resolution: "@emotion/utils@npm:1.2.1"
   checksum: e0b44be0705b56b079c55faff93952150be69e79b660ae70ddd5b6e09fc40eb1319654315a9f34bb479d7f4ec94be6068c061abbb9e18b9778ae180ad5d97c73
   languageName: node
   linkType: hard
 
-"@emotion/weak-memoize@npm:^0.3.1":
+"@emotion/weak-memoize@npm:^0.3.0, @emotion/weak-memoize@npm:^0.3.1":
   version: 0.3.1
   resolution: "@emotion/weak-memoize@npm:0.3.1"
   checksum: b2be47caa24a8122622ea18cd2d650dbb4f8ad37b636dc41ed420c2e082f7f1e564ecdea68122b546df7f305b159bf5ab9ffee872abd0f052e687428459af594
@@ -3728,6 +3741,7 @@ __metadata:
     "@babel/preset-typescript": ^7.21.5
     "@commitlint/cli": 17.6.7
     "@commitlint/config-conventional": 17.6.7
+    "@emotion/cache": ~11.10.7
     "@emotion/react": 11.11.1
     "@emotion/styled": 11.11.0
     "@graasp/sdk": 1.1.3
@@ -3764,6 +3778,7 @@ __metadata:
     "@types/react-dom": 18.2.7
     "@types/react-router-dom": 5.3.3
     "@types/react-text-mask": 5.4.11
+    "@types/stylis": 4.2.0
     "@types/uuid": 9.0.2
     "@typescript-eslint/eslint-plugin": 6.2.0
     "@typescript-eslint/parser": 6.2.0
@@ -3812,12 +3827,15 @@ __metadata:
     rollup-plugin-scss: 4.0.0
     sass: 1.64.1
     storybook: 7.2.1
+    stylis: ^4.1.3
+    stylis-plugin-rtl: ^2.1.1
     ts-jest: 29.1.1
     ts-node: 10.9.1
     typescript: 5.1.6
     uuid: 9.0.0
     wait-on: 7.0.1
   peerDependencies:
+    "@emotion/cache": ~11.10.7
     "@emotion/react": ~11.10.6 || ~11.11.0
     "@emotion/styled": ~11.10.6 || ~11.11.0
     "@mui/icons-material": ~5.11.9 || ~5.13.0 || ~5.14.0
@@ -3830,6 +3848,8 @@ __metadata:
     react-dom: ^17.0.2
     react-i18next: ^12.2.0
     react-router-dom: ^6.11.0
+    stylis: ^4.1.3
+    stylis-plugin-rtl: ^2.1.1
   peerDependenciesMeta:
     ag-grid-community:
       optional: true
@@ -8283,6 +8303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/stylis@npm:4.2.0":
+  version: 4.2.0
+  resolution: "@types/stylis@npm:4.2.0"
+  checksum: 02a47584acd2fcb664f7d8270a69686c83752bdfb855f804015d33116a2b09c0b2ac535213a4a7b6d3a78b2915b22b4024cce067ae979beee0e4f8f5fdbc26a9
+  languageName: node
+  linkType: hard
+
 "@types/testing-library__jest-dom@npm:^5.9.1":
   version: 5.14.5
   resolution: "@types/testing-library__jest-dom@npm:5.14.5"
@@ -10721,6 +10748,13 @@ __metadata:
   bin:
     cssesc: bin/cssesc
   checksum: f8c4ababffbc5e2ddf2fa9957dda1ee4af6048e22aeda1869d0d00843223c1b13ad3f5d88b51caa46c994225eacb636b764eb807a8883e2fb6f99b4f4e8c48b2
+  languageName: node
+  linkType: hard
+
+"cssjanus@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "cssjanus@npm:2.1.0"
+  checksum: 87d02bb8a54aeb046fab0c63e32bc73a6f776d33f07b1ead29cbdd65bc6f5078f28bae85653b0fcae528817e54a91fcc8cd9f4fcb98a3c4e229628d8a10439c3
   languageName: node
   linkType: hard
 
@@ -20006,10 +20040,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stylis-plugin-rtl@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "stylis-plugin-rtl@npm:2.1.1"
+  dependencies:
+    cssjanus: ^2.0.1
+  peerDependencies:
+    stylis: 4.x
+  checksum: 262d2c762216556ed3dc8218ea5929ae24b4b0fae020eb41c217911e6628374009d1e1b24256ed6a2f39cbbf302a877f2efe912b628c71dd15fde90866ca54ca
+  languageName: node
+  linkType: hard
+
+"stylis@npm:4.1.4":
+  version: 4.1.4
+  resolution: "stylis@npm:4.1.4"
+  checksum: cd929bd89709def13b47e6c16b11317bf996a09b4e987fc45a235549c3adf49d41531e017d7df511daa095bc9468c923ae9094a934fe9c62440b7351874dafb7
+  languageName: node
+  linkType: hard
+
 "stylis@npm:4.2.0":
   version: 4.2.0
   resolution: "stylis@npm:4.2.0"
   checksum: 0eb6cc1b866dc17a6037d0a82ac7fa877eba6a757443e79e7c4f35bacedbf6421fadcab4363b39667b43355cbaaa570a3cde850f776498e5450f32ed2f9b7584
+  languageName: node
+  linkType: hard
+
+"stylis@npm:^4.1.3":
+  version: 4.3.0
+  resolution: "stylis@npm:4.3.0"
+  checksum: 6120de3f03eacf3b5adc8e7919c4cca991089156a6badc5248752a3088106afaaf74996211a6817a7760ebeadca09004048eea31875bd8d4df51386365c50025
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `ThemeContext` provides the theme + direction support, and returns a language select to be displayed wherever you want in the interface. 

close #472 