### PR TITLE
503 resize file

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "storybook:build": "storybook build"
   },
   "dependencies": {
-    "@graasp/sdk": "1.2.1",
+    "@graasp/sdk": "github:graasp/graasp-sdk#248-max-width-file",
     "http-status-codes": "2.2.0",
     "immutable": "4.3.2",
     "katex": "0.16.8",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "storybook:build": "storybook build"
   },
   "dependencies": {
-    "@graasp/sdk": "github:graasp/graasp-sdk#248-max-width-file",
+    "@graasp/sdk": "1.4.0",
     "http-status-codes": "2.2.0",
     "immutable": "4.3.2",
     "katex": "0.16.8",

--- a/src/Collapse/withCollapse.tsx
+++ b/src/Collapse/withCollapse.tsx
@@ -2,20 +2,10 @@ import React from 'react';
 
 import Collapse from './Collapse';
 
-interface WithCollapseProps {
-  itemName: string;
-}
-
-function withCollapse({ itemName }: WithCollapseProps) {
+const withCollapse = <T extends { name: string }>({ item }: { item: T }) => {
   return (component: JSX.Element): JSX.Element => {
-    class ComponentWithCollapse extends React.Component {
-      render(): JSX.Element {
-        return <Collapse title={itemName}>{component}</Collapse>;
-      }
-    }
-
-    return <ComponentWithCollapse />;
+    return <Collapse title={item.name}>{component}</Collapse>;
   };
-}
+};
 
 export default withCollapse;

--- a/src/items/AppItem.tsx
+++ b/src/items/AppItem.tsx
@@ -154,7 +154,7 @@ const AppItem = ({
   }
 
   if (showCollapse) {
-    component = withCollapse({ itemName: item.name })(component);
+    component = withCollapse({ item })(component);
   }
 
   return component;

--- a/src/items/DocumentItem.tsx
+++ b/src/items/DocumentItem.tsx
@@ -102,7 +102,7 @@ const DocumentItem: FC<DocumentItemProps> = ({
   }
 
   if (showCollapse) {
-    component = withCollapse({ itemName: item.name })(component);
+    component = withCollapse({ item })(component);
   }
 
   return component;

--- a/src/items/FileImage.tsx
+++ b/src/items/FileImage.tsx
@@ -1,20 +1,15 @@
-import { styled } from '@mui/material';
-import { SxProps } from '@mui/material';
-
 import React, { FC } from 'react';
 
 export interface FileImageProps {
   alt: string;
   url?: string;
   id?: string;
-  sx?: SxProps;
 }
 
-const FileImage: FC<FileImageProps> = ({ id, url, alt, sx }) => {
-  const StyledImage = styled('img')({
-    maxWidth: '100%',
-  });
-  return <StyledImage id={id} sx={sx} src={url} alt={alt} title={alt} />;
+const FileImage: FC<FileImageProps> = ({ id, url, alt }) => {
+  return (
+    <img id={id} src={url} alt={alt} title={alt} style={{ maxWidth: '100%' }} />
+  );
 };
 
 export default FileImage;

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -1,9 +1,14 @@
-// TODO
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
 
-import { ItemType, LocalFileItemType, MimeTypes, convertJs } from '@graasp/sdk';
+import {
+  ItemType,
+  LocalFileItemType,
+  MaxWidth,
+  MimeTypes,
+  convertJs,
+} from '@graasp/sdk';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
 import { TABLE_CATEGORIES } from '../utils/storybook';
@@ -52,6 +57,71 @@ export const Image: Story = {
       description: 'my image description',
       path: 'item-path',
       settings: {},
+      creator: MOCK_MEMBER,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
+  },
+};
+
+export const BigContainedImage: Story = {
+  loaders: [
+    async () => ({
+      content: await fetch('https://picsum.photos/1000').then((r) => r.blob()),
+    }),
+  ],
+  args: {
+    item: convertJs<LocalFileItemType>({
+      id: 'my-id',
+      name: 'my item name',
+      extra: {
+        [ItemType.LOCAL_FILE]: {
+          path: 'https://picsum.photos/1000',
+          mimetype: MimeTypes.Image.PNG,
+          name: 'original file name',
+          size: 2600,
+          altText: 'my image alt text',
+        },
+      },
+      type: ItemType.LOCAL_FILE,
+      description:
+        'This image is really big but is contrained to its container',
+      path: 'item-path',
+      settings: {
+        maxWidth: MaxWidth.Small,
+      },
+      creator: MOCK_MEMBER,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
+  },
+};
+
+export const SmallContainedImage: Story = {
+  loaders: [
+    async () => ({
+      content: await fetch('https://picsum.photos/100').then((r) => r.blob()),
+    }),
+  ],
+  args: {
+    item: convertJs<LocalFileItemType>({
+      id: 'my-id',
+      name: 'my item name',
+      extra: {
+        [ItemType.LOCAL_FILE]: {
+          path: 'https://picsum.photos/100',
+          mimetype: MimeTypes.Image.PNG,
+          name: 'original file name',
+          size: 2600,
+          altText: 'my image alt text',
+        },
+      },
+      type: ItemType.LOCAL_FILE,
+      description: 'This image is small but is contrained to its big container',
+      path: 'item-path',
+      settings: {
+        maxWidth: MaxWidth.Large,
+      },
       creator: MOCK_MEMBER,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -85,7 +85,7 @@ export const BigContainedImage: Story = {
       },
       type: ItemType.LOCAL_FILE,
       description:
-        'This image is really big but is contrained to its container',
+        'This image is really big but is constrained to its container',
       path: 'item-path',
       settings: {
         maxWidth: MaxWidth.Small,
@@ -117,7 +117,8 @@ export const SmallContainedImage: Story = {
         },
       },
       type: ItemType.LOCAL_FILE,
-      description: 'This image is small but is contrained to its big container',
+      description:
+        'This image is small but is constrained to its big container',
       path: 'item-path',
       settings: {
         maxWidth: MaxWidth.Large,

--- a/src/items/FileItem.tsx
+++ b/src/items/FileItem.tsx
@@ -4,7 +4,13 @@ import Skeleton from '@mui/material/Skeleton';
 
 import React, { useEffect, useState } from 'react';
 
-import { ItemType, MimeTypes, getFileExtra, getS3FileExtra } from '@graasp/sdk';
+import {
+  ItemType,
+  MaxWidth,
+  MimeTypes,
+  getFileExtra,
+  getS3FileExtra,
+} from '@graasp/sdk';
 import {
   ItemRecord,
   LocalFileItemTypeRecord,
@@ -167,7 +173,7 @@ const FileItem = ({
       disableGutters
       // m=0 align the file to the left.
       sx={{ m: 0, ...sx }}
-      maxWidth={item.settings.maxWidth ?? 'xl'}
+      maxWidth={item.settings.maxWidth ?? MaxWidth.ExtraLarge}
     >
       {getComponent()}
     </Container>

--- a/src/items/FileItem.tsx
+++ b/src/items/FileItem.tsx
@@ -12,7 +12,6 @@ import {
   getS3FileExtra,
 } from '@graasp/sdk';
 import {
-  ItemRecord,
   LocalFileItemTypeRecord,
   S3FileItemTypeRecord,
 } from '@graasp/sdk/frontend';
@@ -162,27 +161,12 @@ const FileItem = ({
     );
   };
 
-  // todo: add more file extensions
-
-  // the container allows to resize the file to a given responsive standard
-  // There is a threadoff because of the description:
-  // - description does not look good when align to the left while the file is centered
-  // - description does not look good when centered/cut alongside the centered file
-  let fileItem = (
-    <Container
-      disableGutters
-      // m=0 align the file to the left.
-      sx={{ m: 0, ...sx }}
-      maxWidth={item.settings.maxWidth ?? MaxWidth.ExtraLarge}
-    >
-      {getComponent()}
-    </Container>
-  );
+  let fileItem = getComponent();
 
   // display element with caption
   if (showCaption) {
     fileItem = withCaption({
-      item: item as ItemRecord,
+      item,
       onSave: onSaveCaption,
       onCancel: onCancelCaption,
       edit: editCaption,
@@ -192,10 +176,23 @@ const FileItem = ({
   }
 
   if (showCollapse) {
-    fileItem = withCollapse({ itemName: item.name })(fileItem);
+    fileItem = withCollapse({ item })(fileItem);
   }
 
-  return fileItem;
+  // the container allows to resize the file to a given responsive standard
+  // There is a tradeoff because of the description:
+  // - description does not look good when align to the left while the file is centered
+  // - description does not look good when centered/cut alongside the centered file
+  return (
+    <Container
+      disableGutters
+      // m=0 align the file to the left.
+      sx={{ m: 0, ...sx }}
+      maxWidth={item.settings.maxWidth ?? MaxWidth.ExtraLarge}
+    >
+      {fileItem}
+    </Container>
+  );
 };
 
 export default React.memo(FileItem);

--- a/src/items/FileItem.tsx
+++ b/src/items/FileItem.tsx
@@ -1,12 +1,12 @@
-import { SxProps } from '@mui/material';
+import { Container, SxProps } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Skeleton from '@mui/material/Skeleton';
 
-import React, { FC, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { ItemType, MimeTypes, getFileExtra, getS3FileExtra } from '@graasp/sdk';
 import {
-  DocumentItemTypeRecord,
+  ItemRecord,
   LocalFileItemTypeRecord,
   S3FileItemTypeRecord,
 } from '@graasp/sdk/frontend';
@@ -35,8 +35,8 @@ export interface FileItemProps {
   editCaption?: boolean;
   errorMessage?: string;
   id?: string;
-  item: LocalFileItemTypeRecord | S3FileItemTypeRecord | DocumentItemTypeRecord;
-  maxHeight?: number;
+  item: LocalFileItemTypeRecord | S3FileItemTypeRecord;
+  maxHeight?: number | string;
   onSaveCaption?: (text: string) => void;
   onCancelCaption?: (text: string) => void;
   /**
@@ -50,7 +50,7 @@ export interface FileItemProps {
   sx?: SxProps;
 }
 
-const FileItem: FC<FileItemProps> = ({
+const FileItem = ({
   content,
   fileUrl,
   defaultItem,
@@ -68,7 +68,7 @@ const FileItem: FC<FileItemProps> = ({
   showCollapse,
   sx,
   pdfViewerLink,
-}) => {
+}: FileItemProps): JSX.Element => {
   const [url, setUrl] = useState<string>();
 
   useEffect(() => {
@@ -122,9 +122,7 @@ const FileItem: FC<FileItemProps> = ({
 
     if (mimetype) {
       if (MimeTypes.isImage(mimetype)) {
-        return (
-          <FileImage id={id} url={url} alt={altText || item.name} sx={sx} />
-        );
+        return <FileImage id={id} url={url} alt={altText || item.name} />;
       } else if (MimeTypes.isAudio(mimetype)) {
         return <FileAudio id={id} url={url} type={mimetype} sx={sx} />;
       } else if (MimeTypes.isVideo(mimetype)) {
@@ -159,12 +157,26 @@ const FileItem: FC<FileItemProps> = ({
   };
 
   // todo: add more file extensions
-  let fileItem = getComponent();
+
+  // the container allows to resize the file to a given responsive standard
+  // There is a threadoff because of the description:
+  // - description does not look good when align to the left while the file is centered
+  // - description does not look good when centered/cut alongside the centered file
+  let fileItem = (
+    <Container
+      disableGutters
+      // m=0 align the file to the left.
+      sx={{ m: 0, ...sx }}
+      maxWidth={item.settings.maxWidth ?? 'xl'}
+    >
+      {getComponent()}
+    </Container>
+  );
 
   // display element with caption
   if (showCaption) {
     fileItem = withCaption({
-      item,
+      item: item as ItemRecord,
       onSave: onSaveCaption,
       onCancel: onCancelCaption,
       edit: editCaption,

--- a/src/items/FilePdf.stories.tsx
+++ b/src/items/FilePdf.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import React from 'react';
+
+import { TABLE_CATEGORIES } from '../utils/storybook';
+import FilePdf from './FilePdf';
+
+const meta: Meta<typeof FilePdf> = {
+  title: 'Items/FilePdf',
+  component: FilePdf,
+
+  argTypes: {
+    sx: {
+      table: {
+        category: TABLE_CATEGORIES.MUI,
+      },
+    },
+  },
+  render: (args) => {
+    return <FilePdf {...args} />;
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FilePdf>;
+
+export const Pdf: Story = {
+  args: {
+    url: 'https://www.africau.edu/images/default/sample.pdf',
+  },
+};

--- a/src/items/H5PItem.tsx
+++ b/src/items/H5PItem.tsx
@@ -104,7 +104,7 @@ const H5PItem: FC<H5PItemProps> = ({
   );
 
   if (showCollapse) {
-    iframeH5Pitem = withCollapse({ itemName })(iframeH5Pitem);
+    iframeH5Pitem = withCollapse({ item: { name: itemName } })(iframeH5Pitem);
   }
 
   return iframeH5Pitem;

--- a/src/items/LinkItem.tsx
+++ b/src/items/LinkItem.tsx
@@ -198,7 +198,7 @@ const LinkItem: FC<LinkItemProps> = ({
   }
 
   if (showCollapse) {
-    linkItem = withCollapse({ itemName: name })(linkItem);
+    linkItem = withCollapse({ item: { name } })(linkItem);
   }
 
   return linkItem;

--- a/src/items/withCaption.tsx
+++ b/src/items/withCaption.tsx
@@ -2,14 +2,12 @@ import Grid from '@mui/material/Grid';
 
 import React from 'react';
 
-import { ItemRecord } from '@graasp/sdk/frontend';
-
 import TextEditor from '../TextEditor';
 
 const DEFAULT_ITEM_DESCRIPTION = '';
 
-interface WithCaptionProps {
-  item: ItemRecord;
+interface WithCaptionProps<T> {
+  item: T;
   edit?: boolean;
   onSave?: (text: string) => void;
   onCancel?: (text: string) => void;
@@ -18,7 +16,7 @@ interface WithCaptionProps {
   cancelButtonId?: string;
 }
 
-function withCaption({
+function withCaption<T extends { description: string | null }>({
   item,
   edit,
   onSave,
@@ -26,7 +24,7 @@ function withCaption({
   saveButtonText,
   saveButtonId,
   cancelButtonId,
-}: WithCaptionProps) {
+}: WithCaptionProps<T>) {
   return (component: JSX.Element): JSX.Element => {
     class ComponentWithCaption extends React.Component {
       render(): JSX.Element {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,9 +3765,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#248-max-width-file":
-  version: 1.2.1
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=d135407c1c55dc51d79ea2af3200fafeaf2a49d9"
+"@graasp/sdk@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@graasp/sdk@npm:1.4.0"
   dependencies:
     "@aws-sdk/client-s3": 3.370.0
     "@fastify/secure-session": 6.1.0
@@ -3780,7 +3780,7 @@ __metadata:
     typeorm: 0.3.17
     uuid: 9.0.0
     validator: 13.11.0
-  checksum: afd0d33f22842d7f381183d646de4b398274ab0fe439bc5d8ba034c96dc047ca4d48b847edd8c2c01073c52eabf278900e1fd4c63718a0a31d282cb35830374c
+  checksum: 224ed990ed7b68fe4b463d2d1e24fc503c5f5434703cb818a54d22ee9aa8e9997c3a02768ceec082bea604853aa4804ac4d454c746e38089e3e327e0ffcd4c27
   languageName: node
   linkType: hard
 
@@ -3798,7 +3798,7 @@ __metadata:
     "@emotion/cache": ~11.11.0
     "@emotion/react": 11.11.1
     "@emotion/styled": 11.11.0
-    "@graasp/sdk": "github:graasp/graasp-sdk#248-max-width-file"
+    "@graasp/sdk": 1.4.0
     "@mdx-js/react": 2.3.0
     "@mui/icons-material": 5.14.3
     "@mui/lab": 5.0.0-alpha.140

--- a/yarn.lock
+++ b/yarn.lock
@@ -3767,7 +3767,7 @@ __metadata:
 
 "@graasp/sdk@github:graasp/graasp-sdk#248-max-width-file":
   version: 1.2.1
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=d6a1d495afbdf7273a3763e13a3ecc2e757f5317"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=d135407c1c55dc51d79ea2af3200fafeaf2a49d9"
   dependencies:
     "@aws-sdk/client-s3": 3.370.0
     "@fastify/secure-session": 6.1.0
@@ -3780,7 +3780,7 @@ __metadata:
     typeorm: 0.3.17
     uuid: 9.0.0
     validator: 13.11.0
-  checksum: 116d6f19cfb18cf106af2e9f2b7a3838723bd2048c55bbbf3997c02c10a6c07808b6031b67cbcb5f875ccce7bbe8030a21ea68c285cae7a04a4b7c3e53b12a71
+  checksum: afd0d33f22842d7f381183d646de4b398274ab0fe439bc5d8ba034c96dc047ca4d48b847edd8c2c01073c52eabf278900e1fd4c63718a0a31d282cb35830374c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,9 +3765,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:1.2.1":
+"@graasp/sdk@github:graasp/graasp-sdk#248-max-width-file":
   version: 1.2.1
-  resolution: "@graasp/sdk@npm:1.2.1"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=d6a1d495afbdf7273a3763e13a3ecc2e757f5317"
   dependencies:
     "@aws-sdk/client-s3": 3.370.0
     "@fastify/secure-session": 6.1.0
@@ -3780,7 +3780,7 @@ __metadata:
     typeorm: 0.3.17
     uuid: 9.0.0
     validator: 13.11.0
-  checksum: 8507f3157e77a1cf0fb9e01a32c72cbfdb8bd3fd5a960a5fa299dbe36eba4a6f28f5f094a5d09214599e54a1fd91b95e945f80525a6165e4caf96ca9822544b7
+  checksum: 116d6f19cfb18cf106af2e9f2b7a3838723bd2048c55bbbf3997c02c10a6c07808b6031b67cbcb5f875ccce7bbe8030a21ea68c285cae7a04a4b7c3e53b12a71
   languageName: node
   linkType: hard
 
@@ -3798,7 +3798,7 @@ __metadata:
     "@emotion/cache": ~11.11.0
     "@emotion/react": 11.11.1
     "@emotion/styled": 11.11.0
-    "@graasp/sdk": 1.2.1
+    "@graasp/sdk": "github:graasp/graasp-sdk#248-max-width-file"
     "@mdx-js/react": 2.3.0
     "@mui/icons-material": 5.14.3
     "@mui/lab": 5.0.0-alpha.140


### PR DESCRIPTION
`FileItem` is updated to add a container with a `maxWidth` property.
Default is `xl`.

The best would be to center the image, but it's not really clear because of the description. I've opted for a left align, to keep the description always full sized.

Let me know if you prefer to center, and have an ugly look for small images (small image is centered, but the description is align left). It might be better that way, to enforce bigger images? 

close #503 