### PR TITLE
feat: add download button menu item

### DIFF
--- a/src/buttons/DownloadButton/DownloadButton.stories.tsx
+++ b/src/buttons/DownloadButton/DownloadButton.stories.tsx
@@ -1,5 +1,8 @@
+import { expect } from '@storybook/jest';
 import type { StoryObj } from '@storybook/react';
+import { userEvent, within } from '@storybook/testing-library';
 
+import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import DownloadButton from './DownloadButton';
 
@@ -39,4 +42,25 @@ export default {
 
 type Story = StoryObj<typeof DownloadButton>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByLabelText('download'));
+
+    expect(args.handleDownload).toHaveBeenCalled();
+  },
+};
+
+export const MenuItem: Story = {
+  args: {
+    type: ActionButton.MENU_ITEM,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByText('Download'));
+
+    expect(args.handleDownload).toHaveBeenCalled();
+  },
+};

--- a/src/buttons/DownloadButton/DownloadButton.tsx
+++ b/src/buttons/DownloadButton/DownloadButton.tsx
@@ -1,12 +1,14 @@
 import GetAppIcon from '@mui/icons-material/GetApp';
 import { CircularProgressProps, IconButton } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import MenuItem from '@mui/material/MenuItem';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 
 import React, { FC, MouseEventHandler } from 'react';
 
 import { DEFAULT_LOADER_SIZE } from '../../constants';
-import { ActionButtonVariant } from '../../types';
+import { ActionButton, ActionButtonVariant } from '../../types';
 
 export interface DownloadButtonProps {
   ariaLabel: string;
@@ -40,18 +42,25 @@ const DownloadButton: FC<DownloadButtonProps> = ({
   isLoading = false,
   loaderColor = 'primary',
   loaderSize = DEFAULT_LOADER_SIZE,
-  title = 'download',
+  title = 'Download',
   placement = 'bottom',
   type = 'icon',
 }) => {
-  if (isLoading) {
-    return <CircularProgress color={loaderColor} size={loaderSize} />;
-  }
-
   switch (type) {
-    case 'menuItem':
-    case 'icon':
+    case ActionButton.MENU_ITEM:
+      return (
+        <MenuItem key={title} onClick={handleDownload}>
+          <ListItemIcon>
+            <GetAppIcon />
+          </ListItemIcon>
+          {title}
+        </MenuItem>
+      );
+    case ActionButton.ICON_BUTTON:
     default:
+      if (isLoading) {
+        return <CircularProgress color={loaderColor} size={loaderSize} />;
+      }
       return (
         <Tooltip title={title} placement={placement}>
           <span>


### PR DESCRIPTION
I'll use this to add the download button in the item menu in builder instead of in the "header".