### PR TITLE
fix: allow better typing for Context enum and add color for account

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "storybook:test-ci": "wait-on http://127.0.0.1:6006 && yarn storybook:test"
   },
   "dependencies": {
-    "@graasp/sdk": "2.0.1",
+    "@graasp/sdk": "2.1.0",
     "http-status-codes": "2.3.0",
     "katex": "0.16.9",
     "lodash.truncate": "4.4.2",

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -17,7 +17,7 @@ export const buildHeaderGradient = (color: string): string =>
   `linear-gradient(90deg, ${PRIMARY_COLOR} 0%, ${PRIMARY_COLOR} 35%, ${color} 100%);`;
 
 export type HeaderProps = {
-  context?: Context;
+  context?: `${Context}` | Context;
   centerContent?: React.ReactElement;
   handleDrawerOpen?: () => void;
   handleDrawerClose?: () => void;

--- a/src/Main/Main.tsx
+++ b/src/Main/Main.tsx
@@ -22,7 +22,7 @@ const DrawerHeaderContainer = styled('div')(({ theme }) => ({
 }));
 
 export interface MainProps {
-  context?: Context;
+  context?: `${Context}` | Context;
   children?: JSX.Element | JSX.Element[];
   fullScreen?: boolean;
   /**

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -6,13 +6,14 @@ import { Context } from '@graasp/sdk';
 export const PRIMARY_COLOR = '#5050d2';
 export const SECONDARY_COLOR = '#FFFFFF';
 
-export const AccentColors = {
+export const AccentColors: { [K in Context]: string } = {
   [Context.Builder]: '#1ecaa5',
   [Context.Player]: '#009eff',
   [Context.Library]: '#9300c6',
   [Context.Analytics]: '#0707a3',
+  [Context.Account]: '#e3dc31',
   [Context.Unknown]: '#1ecaa5',
-};
+} as const;
 
 export const theme = createTheme({
   palette: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3781,9 +3781,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:2.0.1":
-  version: 2.0.1
-  resolution: "@graasp/sdk@npm:2.0.1"
+"@graasp/sdk@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@graasp/sdk@npm:2.1.0"
   dependencies:
     "@aws-sdk/client-s3": "npm:3.441.0"
     "@graasp/etherpad-api": "npm:2.1.1"
@@ -3792,7 +3792,7 @@ __metadata:
     js-cookie: "npm:3.0.5"
     uuid: "npm:9.0.1"
     validator: "npm:13.11.0"
-  checksum: e711ed58168715fb412dffa116c9813256e16a9c9185572fd6e1fab41878b5b600514b1cc50d0595ec54853811d0a9752a92ccebf8127744766441b33f502a72
+  checksum: 62e4e004d3a65b0e396b0b5e8efd3c19eecd7bf020db8962dc3c6fa145d98f4688c22552d026576e4b62ab3711c1efcd9fae40f5e7484bdb16d5da41d4e838eb
   languageName: node
   linkType: hard
 
@@ -3810,7 +3810,7 @@ __metadata:
     "@emotion/cache": "npm:~11.11.0"
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:11.11.0"
-    "@graasp/sdk": "npm:2.0.1"
+    "@graasp/sdk": "npm:2.1.0"
     "@mui/icons-material": "npm:5.14.16"
     "@mui/lab": "npm:5.0.0-alpha.151"
     "@mui/material": "npm:5.14.16"


### PR DESCRIPTION
This PR updates:
- sdk to 2.1.0 (with account in `Context`) and necessary changes for types to work a little better