### PR TITLE
fix: add a disabled prop to the select

### DIFF
--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -80,3 +80,14 @@ export const Standard: Story = {
     values,
   },
 };
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: 'admin',
+    values: [
+      { value: 'admin', text: 'admin' },
+      { value: 'read', text: 'read' },
+    ],
+  },
+};

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 type Props<T> = {
   buildOptionId?: (v: T) => string;
   className?: string;
+  disabled?: boolean;
   color?: MuiSelectProps['color'];
   defaultValue?: T;
   value?: T;
@@ -25,6 +26,7 @@ function Select<T extends string | number | readonly string[] | undefined>({
   buildOptionId,
   className,
   color,
+  disabled = false,
   defaultValue,
   displayEmpty,
   id,
@@ -39,7 +41,7 @@ function Select<T extends string | number | readonly string[] | undefined>({
 }: Props<T>): JSX.Element {
   const showLabel = Boolean(labelId ?? label);
   return (
-    <FormControl sx={{ mt: 1 }} size={size}>
+    <FormControl sx={{ mt: 1 }} size={size} disabled={disabled}>
       {showLabel && <InputLabel id={labelId}>{label}</InputLabel>}
       <MuiSelect
         labelId={labelId}


### PR DESCRIPTION
This PR adds a `disabled` prop on the select to completely disable the select:

<img width="117" alt="Screenshot 2024-01-09 at 17 41 20" src="https://github.com/graasp/graasp-ui/assets/39373170/df751553-9753-4413-9642-5062d3d354bf">
