### PR TITLE
fix!: use `domLayout='autoHeight'` to autosize the table

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "post-commit": "git status",
     "pre-commit": "yarn check",
     "pre-push": "yarn build",
-    "storybook": "storybook dev",
+    "storybook": "storybook dev --port 65000",
     "storybook:build": "storybook build",
     "storybook:preview": "http-server storybook-static --port 6006 --silent",
     "storybook:test": "test-storybook --coverage",

--- a/src/TableComponent/Table.stories.tsx
+++ b/src/TableComponent/Table.stories.tsx
@@ -224,7 +224,6 @@ Simple.play = async ({ args, canvasElement }) => {
 
 export const SimpleWithDrag: Story = {
   args: {
-    tableHeight: 300,
     enableDrag: true,
     columnDefs: [
       {
@@ -252,7 +251,6 @@ export const SimpleWithDrag: Story = {
 
 export const Empty: Story = {
   args: {
-    tableHeight: 300,
     columnDefs: [
       {
         headerCheckboxSelection: true,

--- a/src/TableComponent/Table.stories.tsx
+++ b/src/TableComponent/Table.stories.tsx
@@ -141,7 +141,6 @@ type Story = StoryObj<typeof Table>;
 
 export const Simple: Story = {
   args: {
-    tableHeight: 300,
     columnDefs: [
       {
         field: 'name',

--- a/src/TableComponent/Table.tsx
+++ b/src/TableComponent/Table.tsx
@@ -63,7 +63,6 @@ export type TableProps<T = unknown> = {
   suppressCellFocus?: boolean;
   suppressRowClickSelection?: boolean;
   sx?: SxProps;
-  tableHeight?: number | string;
   onSortChanged?: (event: SortChangedEvent) => void;
   ToolbarActions?: ({ selectedIds }: { selectedIds: string[] }) => JSX.Element;
   /**
@@ -255,6 +254,8 @@ function GraaspTable<T>({
       <StyledBox className={className} id={id} sx={sx}>
         <AgGridReact
           domLayout='autoHeight'
+          // used to remove the error with ResizeObserver, instead uses polling to periodically update the width and height
+          suppressBrowserResizeObserver
           onGridReady={onGridReady}
           ref={gridRef}
           columnDefs={buildColumnDefs()}

--- a/src/TableComponent/Table.tsx
+++ b/src/TableComponent/Table.tsx
@@ -33,7 +33,7 @@ import { suppressKeyboardEventForParentCell } from './utils';
 const DRAG_COLUMN_WIDTH = 22;
 const ITEMS_DEFAULT_PAGE_SIZE = 10;
 
-export interface TableProps<T = unknown> {
+export type TableProps<T = unknown> = {
   className?: string;
   /**
    * definition of the columns following AG Grid definitions
@@ -76,7 +76,7 @@ export interface TableProps<T = unknown> {
   totalCount?: number;
   labelDisplayedRows?: TablePaginationProps['labelDisplayedRows'];
   pageSize?: number;
-}
+};
 
 const StyledDiv = styled('div')(({ theme }) => ({
   width: '100%',
@@ -107,12 +107,12 @@ const DEFAULT_COL_DEF = {
   flex: 1,
 };
 
-const StyledBox = styled(Box, {
-  shouldForwardProp: (prop: string) => prop !== 'tableHeight',
-})<{ tableHeight: string | number }>(({ theme, tableHeight }) => ({
+const StyledBox = styled(
+  Box,
+  {},
+)(({ theme }) => ({
   fontSize: theme.typography.fontSize,
   width: '100%',
-  height: tableHeight,
   [`.${ROW_CLASS_NAME}`]: {
     display: 'flex',
     justifyContent: 'center',
@@ -154,7 +154,6 @@ function GraaspTable<T>({
   labelDisplayedRows,
   pagination = true,
   sx,
-  tableHeight = 500,
   ToolbarActions,
   page = 1,
   onPageChange,
@@ -253,13 +252,9 @@ function GraaspTable<T>({
         NoSelectionToolbar={NoSelectionToolbar}
         countTextFunction={countTextFunction}
       />
-      <StyledBox
-        className={className}
-        id={id}
-        sx={sx}
-        tableHeight={tableHeight}
-      >
+      <StyledBox className={className} id={id} sx={sx}>
         <AgGridReact
+          domLayout='autoHeight'
           onGridReady={onGridReady}
           ref={gridRef}
           columnDefs={buildColumnDefs()}


### PR DESCRIPTION
In this PR:
- fix #668 

And I remove the `tableHeight` prop of the Table component since it is not necessary anymore.