### PR TITLE
feat: navigator render extra item

### DIFF
--- a/src/Navigation/CurrentItemNavigation.tsx
+++ b/src/Navigation/CurrentItemNavigation.tsx
@@ -1,0 +1,56 @@
+import truncate from 'lodash.truncate';
+
+import { Typography } from '@mui/material';
+
+import { DiscriminatedItem, ItemType } from '@graasp/sdk';
+
+import ItemMenu, { ItemMenuProps } from './ItemMenu';
+import { CenterAlignWrapper, ITEM_NAME_MAX_LENGTH, StyledLink } from './utils';
+
+export interface CurrentItemProps {
+  item: DiscriminatedItem;
+  buildBreadcrumbsItemLinkId?: (id: string) => string;
+  buildIconId?: (id: string) => string;
+  buildMenuId?: (id: string) => string;
+  buildMenuItemId?: (id: string) => string;
+  useChildren: ItemMenuProps['useChildren'];
+  buildToItemPath: (id: string) => string;
+  showArrow: boolean;
+}
+const CurrentItemNavigation = ({
+  item,
+  buildBreadcrumbsItemLinkId,
+  buildToItemPath,
+  useChildren,
+  buildIconId,
+  buildMenuId,
+  buildMenuItemId,
+  showArrow,
+}: CurrentItemProps): JSX.Element | null => {
+  return (
+    <CenterAlignWrapper>
+      <StyledLink
+        id={buildBreadcrumbsItemLinkId?.(item.id)}
+        key={item.id}
+        to={buildToItemPath(item?.id)}
+      >
+        <Typography>
+          {truncate(item.name, { length: ITEM_NAME_MAX_LENGTH })}
+        </Typography>
+      </StyledLink>
+      {(item.type === ItemType.FOLDER || showArrow) && (
+        <ItemMenu
+          useChildren={useChildren}
+          itemId={item.id}
+          buildToItemPath={buildToItemPath}
+          buildIconId={buildIconId}
+          buildMenuItemId={buildMenuItemId}
+          buildMenuId={buildMenuId}
+          renderArrow={showArrow}
+        />
+      )}
+    </CenterAlignWrapper>
+  );
+};
+
+export default CurrentItemNavigation;

--- a/src/Navigation/ExtraItemsMenu.tsx
+++ b/src/Navigation/ExtraItemsMenu.tsx
@@ -3,18 +3,24 @@ import { IconButtonProps, Menu, MenuItem, Typography } from '@mui/material';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { ItemAction } from './Navigation';
+import { MenuItemType } from './Navigation';
 import { Separator, StyledIconButton } from './utils';
 
-export type ItemActionsMenuProps = {
+export type ExtraItemsMenuProps = {
   icon?: JSX.Element;
-  itemActions: ItemAction[];
+  menuItems: MenuItemType[];
+  buildIconId?: (id: string) => string;
+  buildMenuId?: (itemId: string) => string;
+  name: string;
 };
 
-const ItemActionsMenu = ({
+const ExtraItemsMenu = ({
   icon = Separator,
-  itemActions,
-}: ItemActionsMenuProps): JSX.Element => {
+  menuItems,
+  buildIconId,
+  buildMenuId,
+  name,
+}: ExtraItemsMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick: IconButtonProps['onClick'] = (event) => {
@@ -30,6 +36,7 @@ const ItemActionsMenu = ({
       <StyledIconButton
         onClick={handleClick}
         aria-haspopup='true'
+        id={buildIconId?.(name)}
         aria-expanded={open ? true : undefined}
       >
         {icon}
@@ -37,6 +44,7 @@ const ItemActionsMenu = ({
       <Menu
         anchorEl={anchorEl}
         open={open}
+        id={buildMenuId?.(name)}
         onClose={handleClose}
         onClick={handleClose}
         anchorOrigin={{
@@ -48,7 +56,7 @@ const ItemActionsMenu = ({
           horizontal: 'left',
         }}
       >
-        {itemActions?.map(({ name, path }) => (
+        {menuItems?.map(({ name, path }) => (
           <MenuItem key={name} component={Link} to={path}>
             <Typography>{name}</Typography>
           </MenuItem>
@@ -58,4 +66,4 @@ const ItemActionsMenu = ({
   );
 };
 
-export default ItemActionsMenu;
+export default ExtraItemsMenu;

--- a/src/Navigation/ExtraItemsNavigation.tsx
+++ b/src/Navigation/ExtraItemsNavigation.tsx
@@ -1,0 +1,41 @@
+import truncate from 'lodash.truncate';
+
+import { Box, SvgIconTypeMap, Typography } from '@mui/material';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
+
+import ExtraItemsMenu from './ExtraItemsMenu';
+import { MenuItemType } from './Navigation';
+import { CenterAlignWrapper, ITEM_NAME_MAX_LENGTH, StyledLink } from './utils';
+
+export interface ExtraItem {
+  name: string;
+  path: string;
+  Icon?: OverridableComponent<SvgIconTypeMap>;
+  menuItems?: MenuItemType[];
+}
+
+const ExtraItemsNavigation = ({
+  extraItems,
+}: {
+  extraItems: ExtraItem[];
+}): JSX.Element[] | null => {
+  return extraItems.map(({ Icon, name, path, menuItems }) => (
+    <CenterAlignWrapper>
+      {/* margin set to -2 as menu list has a default style for text indent
+        with the same value, So to align menu items with this box menu item */}
+      <Box display='flex' gap={2} ml={-2}>
+        {Icon && <Icon />}
+        <StyledLink to={path}>
+          <Typography>
+            {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
+          </Typography>
+        </StyledLink>
+      </Box>
+      {menuItems && menuItems.length > 0 && (
+        <ExtraItemsMenu menuItems={menuItems} name={name} />
+      )}
+    </CenterAlignWrapper>
+  ));
+};
+
+export default ExtraItemsNavigation;

--- a/src/Navigation/ItemActionsMenu.tsx
+++ b/src/Navigation/ItemActionsMenu.tsx
@@ -1,0 +1,61 @@
+import { IconButtonProps, Menu, MenuItem, Typography } from '@mui/material';
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { ItemAction } from './Navigation';
+import { Separator, StyledIconButton } from './utils';
+
+export type ItemActionsMenuProps = {
+  icon?: JSX.Element;
+  itemActions: ItemAction[];
+};
+
+const ItemActionsMenu = ({
+  icon = Separator,
+  itemActions,
+}: ItemActionsMenuProps) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick: IconButtonProps['onClick'] = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (): void => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <StyledIconButton
+        onClick={handleClick}
+        aria-haspopup='true'
+        aria-expanded={open ? true : undefined}
+      >
+        {icon}
+      </StyledIconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        onClick={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+      >
+        {itemActions?.map(({ name, path }) => (
+          <MenuItem key={name} component={Link} to={path}>
+            <Typography>{name}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export default ItemActionsMenu;

--- a/src/Navigation/ItemActionsMenu.tsx
+++ b/src/Navigation/ItemActionsMenu.tsx
@@ -14,7 +14,7 @@ export type ItemActionsMenuProps = {
 const ItemActionsMenu = ({
   icon = Separator,
   itemActions,
-}: ItemActionsMenuProps) => {
+}: ItemActionsMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick: IconButtonProps['onClick'] = (event) => {

--- a/src/Navigation/ItemMenu.tsx
+++ b/src/Navigation/ItemMenu.tsx
@@ -16,6 +16,7 @@ export type ItemMenuProps = {
   icon?: JSX.Element;
   itemId: string;
   useChildren: (...args: unknown[]) => UseQueryResult<DiscriminatedItem[]>;
+  renderArrow?: boolean;
 };
 
 const ItemMenu = ({
@@ -26,6 +27,7 @@ const ItemMenu = ({
   icon = Separator,
   itemId,
   useChildren,
+  renderArrow,
 }: ItemMenuProps): JSX.Element | null => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -40,10 +42,13 @@ const ItemMenu = ({
     setAnchorEl(null);
   };
 
+  if (!items?.length && renderArrow) {
+    // to display icon as a separator specially if there's an extra items after items menu
+    return icon;
+  }
   if (!items?.length) {
     return null;
   }
-
   return (
     <>
       <StyledIconButton

--- a/src/Navigation/Navigation.stories.tsx
+++ b/src/Navigation/Navigation.stories.tsx
@@ -54,7 +54,11 @@ type Story = StoryObj<typeof Navigation>;
 type UseChildrenHookType = ReturnType<ItemMenuProps['useChildren']>;
 
 const item = buildItem('my item');
-const parents = [buildItem('parent 1'), buildItem('parent 2')];
+const parents = [
+  buildItem('parent 1'),
+  buildItem('parent 2'),
+  buildItem('parent 3'),
+];
 const children = [buildItem('child 1'), buildItem('child 2')];
 const useChildren: ItemMenuProps['useChildren'] = (id) => {
   console.debug('show children of ' + id);

--- a/src/Navigation/Navigation.stories.tsx
+++ b/src/Navigation/Navigation.stories.tsx
@@ -2,6 +2,8 @@ import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
 import { within } from '@storybook/testing-library';
 
+import SettingsIcon from '@mui/icons-material/Settings';
+
 import { BrowserRouter } from 'react-router-dom';
 
 import { ItemType, LocalFileItemType, MimeTypes } from '@graasp/sdk';
@@ -194,5 +196,61 @@ export const FileWithParents: Story = {
 
     // 4 = 2 parents + 2 x Home
     expect(canvas.getAllByTestId(dataTestId)).toHaveLength(4);
+  },
+};
+
+const extraItems = [
+  {
+    name: 'Settings',
+    path: '/settings',
+    Icon: SettingsIcon,
+    menuItems: [
+      { name: 'Information', path: '/info' },
+      { name: 'Settings', path: '/settings' },
+      { name: 'Publish', path: '/publish' },
+    ],
+  },
+];
+
+export const FolderWithParentsWithExtraItems: Story = {
+  args: {
+    buildToItemPath,
+    useChildren,
+    item: folder,
+    maxItems: 10,
+    renderRoot: () => {
+      return (
+        <>
+          <HomeMenu selected={menu[0]} elements={menu} />
+          <ItemMenu
+            itemId={item.id}
+            useChildren={() => {
+              return {
+                data: [buildItem('Home item 1'), buildItem('Home item 2')],
+              } as UseChildrenHookType;
+            }}
+            buildToItemPath={buildToItemPath}
+          />
+        </>
+      );
+    },
+    parents,
+    extraItems,
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // current item
+    expect(canvas.getByText(folder.name)).toBeInTheDocument();
+
+    // check parents
+    for (const p of parents) {
+      const b = canvas.getByText(p!.name);
+      expect(b).toBeInTheDocument();
+    }
+
+    // 4 = 2 parents + 2 x Home + current item is a folder + 1 extra item
+    expect(canvas.getAllByTestId(dataTestId)).toHaveLength(6);
   },
 };

--- a/src/Navigation/Navigation.stories.tsx
+++ b/src/Navigation/Navigation.stories.tsx
@@ -54,11 +54,7 @@ type Story = StoryObj<typeof Navigation>;
 type UseChildrenHookType = ReturnType<ItemMenuProps['useChildren']>;
 
 const item = buildItem('my item');
-const parents = [
-  buildItem('parent 1'),
-  buildItem('parent 2'),
-  buildItem('parent 3'),
-];
+const parents = [buildItem('parent 1'), buildItem('parent 2')];
 const children = [buildItem('child 1'), buildItem('child 2')];
 const useChildren: ItemMenuProps['useChildren'] = (id) => {
   console.debug('show children of ' + id);

--- a/src/Navigation/Navigation.tsx
+++ b/src/Navigation/Navigation.tsx
@@ -117,25 +117,22 @@ const Navigation = ({
 
     return extraItems.map(({ Icon, name, path, menuItems }) => (
       <CenterAlignWrapper>
-        {path ? (
-          // margin set to -2 as menu list has a default style for text indent with the same value, So to align menu items with this box menu item
-          <Box display='flex' gap={2} ml={-2}>
-            {Icon && <Icon />}
+        {/* margin set to -2 as menu list has a default style for text indent
+        with the same value, So to align menu items with this box menu item */}
+        <Box display='flex' gap={2} ml={-2}>
+          {Icon && <Icon />}
+          {path ? (
             <StyledLink to={path}>
               <Typography>
                 {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
               </Typography>
             </StyledLink>
-          </Box>
-        ) : (
-          <Box display='flex' gap={2} ml={-2}>
-            {Icon && <Icon />}
+          ) : (
             <Typography>
               {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
             </Typography>
-          </Box>
-        )}
-
+          )}
+        </Box>
         {menuItems && menuItems.length > 0 && (
           <ItemActionsMenu menuItems={menuItems} name={name} />
         )}

--- a/src/Navigation/Navigation.tsx
+++ b/src/Navigation/Navigation.tsx
@@ -1,12 +1,14 @@
 import truncate from 'lodash.truncate';
 
-import { SxProps } from '@mui/material';
+import { SvgIconTypeMap, SxProps } from '@mui/material';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
+import { OverridableComponent } from '@mui/types';
 
 import { DiscriminatedItem, ItemType } from '@graasp/sdk';
 
+import ItemActionsMenu from './ItemActionsMenu';
 import ItemMenu, { ItemMenuProps } from './ItemMenu';
 import { CenterAlignWrapper, ITEM_NAME_MAX_LENGTH, StyledLink } from './utils';
 
@@ -15,7 +17,10 @@ const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
     textIndent: -theme.typography.fontSize,
   },
 }));
-
+export interface ItemAction {
+  name: string;
+  path: string;
+}
 export type NavigationProps = {
   backgroundColor?: string;
   buildBreadcrumbsItemLinkId?: (id: string) => string;
@@ -30,6 +35,9 @@ export type NavigationProps = {
   sx?: SxProps;
   useChildren: ItemMenuProps['useChildren'];
   maxItems?: number;
+  itemActionTitle?: string;
+  ItemActionIcon?: OverridableComponent<SvgIconTypeMap>;
+  itemActions?: ItemAction[];
 };
 
 const Navigation = ({
@@ -46,6 +54,9 @@ const Navigation = ({
   useChildren,
   buildMenuId,
   maxItems = 4,
+  itemActionTitle = '',
+  ItemActionIcon,
+  itemActions = [],
 }: NavigationProps): JSX.Element | null => {
   const renderParents = (): JSX.Element[] | undefined =>
     // need to convert otherwise it returns List<Element>
@@ -96,6 +107,20 @@ const Navigation = ({
       </CenterAlignWrapper>
     );
   };
+  const renderItemActions = (): JSX.Element | null => {
+    if (!item) {
+      return null;
+    }
+
+    return (
+      <CenterAlignWrapper>
+        {ItemActionIcon && <ItemActionIcon />}
+        <Typography>{itemActionTitle}</Typography>
+
+        <ItemActionsMenu itemActions={itemActions} />
+      </CenterAlignWrapper>
+    );
+  };
 
   return (
     <StyledBreadcrumbs
@@ -109,6 +134,7 @@ const Navigation = ({
       <CenterAlignWrapper>{renderRoot?.(item)}</CenterAlignWrapper>
       {item?.id && renderParents()}
       {item?.id && renderCurrentItem()}
+      {itemActions.length > 0 && renderItemActions()}
     </StyledBreadcrumbs>
   );
 };

--- a/src/Navigation/Navigation.tsx
+++ b/src/Navigation/Navigation.tsx
@@ -96,7 +96,7 @@ const Navigation = ({
             {truncate(item.name, { length: ITEM_NAME_MAX_LENGTH })}
           </Typography>
         </StyledLink>
-        {item.type === ItemType.FOLDER && (
+        {(item.type === ItemType.FOLDER || extraItems?.length) && (
           <ItemMenu
             useChildren={useChildren}
             itemId={item.id}
@@ -104,6 +104,7 @@ const Navigation = ({
             buildIconId={buildIconId}
             buildMenuItemId={buildMenuItemId}
             buildMenuId={buildMenuId}
+            renderArrow={Boolean(extraItems?.length)}
           />
         )}
       </CenterAlignWrapper>

--- a/src/Navigation/Navigation.tsx
+++ b/src/Navigation/Navigation.tsx
@@ -1,16 +1,14 @@
-import truncate from 'lodash.truncate';
-
-import { Box, SvgIconTypeMap, SxProps } from '@mui/material';
+import { SxProps } from '@mui/material';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
-import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
-import { OverridableComponent } from '@mui/types';
 
-import { DiscriminatedItem, ItemType } from '@graasp/sdk';
+import { DiscriminatedItem } from '@graasp/sdk';
 
-import ItemActionsMenu from './ExtraItemsMenu';
-import ItemMenu, { ItemMenuProps } from './ItemMenu';
-import { CenterAlignWrapper, ITEM_NAME_MAX_LENGTH, StyledLink } from './utils';
+import CurrentItemNavigation from './CurrentItemNavigation';
+import ExtraItemsNavigation, { ExtraItem } from './ExtraItemsNavigation';
+import { ItemMenuProps } from './ItemMenu';
+import ParentsNavigation from './ParentsNavigation';
+import { CenterAlignWrapper } from './utils';
 
 const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
   '& ol': {
@@ -38,12 +36,7 @@ export interface MenuItemType {
   name: string;
   path: string;
 }
-export interface ExtraItem {
-  name: string;
-  path?: string;
-  Icon?: OverridableComponent<SvgIconTypeMap>;
-  menuItems?: MenuItemType[];
-}
+
 const Navigation = ({
   backgroundColor,
   buildBreadcrumbsItemLinkId,
@@ -60,87 +53,6 @@ const Navigation = ({
   maxItems = 4,
   extraItems,
 }: NavigationProps): JSX.Element | null => {
-  const renderParents = (): JSX.Element[] | undefined =>
-    // need to convert otherwise it returns List<Element>
-    parents?.map(({ name, id }) => (
-      <CenterAlignWrapper key={id}>
-        <StyledLink
-          id={buildBreadcrumbsItemLinkId?.(id)}
-          to={buildToItemPath(id)}
-        >
-          <Typography>
-            {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
-          </Typography>
-        </StyledLink>
-        <ItemMenu
-          useChildren={useChildren}
-          itemId={id}
-          buildToItemPath={buildToItemPath}
-        />
-      </CenterAlignWrapper>
-    ));
-
-  const renderCurrentItem = (): JSX.Element | null => {
-    if (!item) {
-      return null;
-    }
-
-    return (
-      <CenterAlignWrapper>
-        <StyledLink
-          id={buildBreadcrumbsItemLinkId?.(item.id)}
-          key={item.id}
-          to={buildToItemPath(item?.id)}
-        >
-          <Typography>
-            {truncate(item.name, { length: ITEM_NAME_MAX_LENGTH })}
-          </Typography>
-        </StyledLink>
-        {(item.type === ItemType.FOLDER || extraItems?.length) && (
-          <ItemMenu
-            useChildren={useChildren}
-            itemId={item.id}
-            buildToItemPath={buildToItemPath}
-            buildIconId={buildIconId}
-            buildMenuItemId={buildMenuItemId}
-            buildMenuId={buildMenuId}
-            renderArrow={Boolean(extraItems?.length)}
-          />
-        )}
-      </CenterAlignWrapper>
-    );
-  };
-
-  const renderExtraItems = (): JSX.Element[] | null => {
-    if (!extraItems) {
-      return null;
-    }
-
-    return extraItems.map(({ Icon, name, path, menuItems }) => (
-      <CenterAlignWrapper>
-        {/* margin set to -2 as menu list has a default style for text indent
-        with the same value, So to align menu items with this box menu item */}
-        <Box display='flex' gap={2} ml={-2}>
-          {Icon && <Icon />}
-          {path ? (
-            <StyledLink to={path}>
-              <Typography>
-                {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
-              </Typography>
-            </StyledLink>
-          ) : (
-            <Typography>
-              {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
-            </Typography>
-          )}
-        </Box>
-        {menuItems && menuItems.length > 0 && (
-          <ItemActionsMenu menuItems={menuItems} name={name} />
-        )}
-      </CenterAlignWrapper>
-    ));
-  };
-
   return (
     <StyledBreadcrumbs
       sx={sx}
@@ -151,9 +63,27 @@ const Navigation = ({
       style={{ backgroundColor }}
     >
       <CenterAlignWrapper>{renderRoot?.(item)}</CenterAlignWrapper>
-      {item?.id && renderParents()}
-      {item?.id && renderCurrentItem()}
-      {renderExtraItems()}
+      {item?.id && parents && (
+        <ParentsNavigation
+          useChildren={useChildren}
+          parents={parents}
+          buildToItemPath={buildToItemPath}
+          buildBreadcrumbsItemLinkId={buildBreadcrumbsItemLinkId}
+        />
+      )}
+      {item?.id && item && (
+        <CurrentItemNavigation
+          item={item}
+          useChildren={useChildren}
+          buildToItemPath={buildToItemPath}
+          buildBreadcrumbsItemLinkId={buildBreadcrumbsItemLinkId}
+          buildIconId={buildIconId}
+          buildMenuId={buildMenuId}
+          buildMenuItemId={buildMenuItemId}
+          showArrow={Boolean(extraItems?.length)}
+        />
+      )}
+      {extraItems && <ExtraItemsNavigation extraItems={extraItems} />}
     </StyledBreadcrumbs>
   );
 };

--- a/src/Navigation/ParentsNavigation.tsx
+++ b/src/Navigation/ParentsNavigation.tsx
@@ -1,11 +1,11 @@
 import truncate from 'lodash.truncate';
 
-import { Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 
 import { DiscriminatedItem } from '@graasp/sdk';
 
 import ItemMenu, { ItemMenuProps } from './ItemMenu';
-import { CenterAlignWrapper, ITEM_NAME_MAX_LENGTH, StyledLink } from './utils';
+import { ITEM_NAME_MAX_LENGTH, StyledLink } from './utils';
 
 export interface ParentsProps {
   parents: DiscriminatedItem[];
@@ -18,24 +18,31 @@ const ParentsNavigation = ({
   useChildren,
   buildBreadcrumbsItemLinkId,
   buildToItemPath,
-}: ParentsProps): JSX.Element[] | undefined =>
-  // need to convert otherwise it returns List<Element>
-  parents.map(({ name, id }) => (
-    <CenterAlignWrapper key={id}>
-      <StyledLink
-        id={buildBreadcrumbsItemLinkId?.(id)}
-        to={buildToItemPath(id)}
-      >
-        <Typography>
-          {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
-        </Typography>
-      </StyledLink>
-      <ItemMenu
-        useChildren={useChildren}
-        itemId={id}
-        buildToItemPath={buildToItemPath}
-      />
-    </CenterAlignWrapper>
-  ));
-
+}: ParentsProps): JSX.Element => (
+  <Stack direction='row' gap={2}>
+    {parents.map(({ name, id }) => (
+      <Stack key={id}>
+        <Stack direction='row' alignItems='center' justifyContent='center'>
+          <Stack>
+            <StyledLink
+              id={buildBreadcrumbsItemLinkId?.(id)}
+              to={buildToItemPath(id)}
+            >
+              <Typography>
+                {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
+              </Typography>
+            </StyledLink>
+          </Stack>
+          <Stack>
+            <ItemMenu
+              useChildren={useChildren}
+              itemId={id}
+              buildToItemPath={buildToItemPath}
+            />
+          </Stack>
+        </Stack>
+      </Stack>
+    ))}
+  </Stack>
+);
 export default ParentsNavigation;

--- a/src/Navigation/ParentsNavigation.tsx
+++ b/src/Navigation/ParentsNavigation.tsx
@@ -1,0 +1,41 @@
+import truncate from 'lodash.truncate';
+
+import { Typography } from '@mui/material';
+
+import { DiscriminatedItem } from '@graasp/sdk';
+
+import ItemMenu, { ItemMenuProps } from './ItemMenu';
+import { CenterAlignWrapper, ITEM_NAME_MAX_LENGTH, StyledLink } from './utils';
+
+export interface ParentsProps {
+  parents: DiscriminatedItem[];
+  buildBreadcrumbsItemLinkId?: (id: string) => string;
+  useChildren: ItemMenuProps['useChildren'];
+  buildToItemPath: (id: string) => string;
+}
+const ParentsNavigation = ({
+  parents,
+  useChildren,
+  buildBreadcrumbsItemLinkId,
+  buildToItemPath,
+}: ParentsProps): JSX.Element[] | undefined =>
+  // need to convert otherwise it returns List<Element>
+  parents.map(({ name, id }) => (
+    <CenterAlignWrapper key={id}>
+      <StyledLink
+        id={buildBreadcrumbsItemLinkId?.(id)}
+        to={buildToItemPath(id)}
+      >
+        <Typography>
+          {truncate(name, { length: ITEM_NAME_MAX_LENGTH })}
+        </Typography>
+      </StyledLink>
+      <ItemMenu
+        useChildren={useChildren}
+        itemId={id}
+        buildToItemPath={buildToItemPath}
+      />
+    </CenterAlignWrapper>
+  ));
+
+export default ParentsNavigation;


### PR DESCRIPTION
Add an extra props for navigation component to accept extraItems, Basically `extraItems` has the following structure
```
[
  {
    name: "",
    path?: "",
    Icon?: ,
    menuItems?: [
      {
        name: "",
        path: ""
      }
    ]
  }
]

```
![image](https://github.com/graasp/graasp-ui/assets/49619087/bf2f4b70-0c13-4302-97d9-46e03d7749e6)

closes #686 