### PR TITLE
fix: use sx prop passed when there is an src

### DIFF
--- a/src/icons/ItemIcon.stories.tsx
+++ b/src/icons/ItemIcon.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { ItemType, MimeTypes, S3FileItemExtra } from '@graasp/sdk';
+import { ItemType, MimeTypes } from '@graasp/sdk';
 
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import ItemIcon from './ItemIcon';
@@ -128,11 +128,6 @@ export const FancyImage: Story = {
     type: ItemType.S3_FILE,
     color: 'red',
     sx: { fontSize: '3rem' },
-    extra: {
-      [ItemType.S3_FILE]: {
-        name: '',
-        mimetype: MimeTypes.Image.JPEG,
-      },
-    } as S3FileItemExtra,
+    mimetype: MimeTypes.Image.JPEG,
   },
 };

--- a/src/icons/ItemIcon.stories.tsx
+++ b/src/icons/ItemIcon.stories.tsx
@@ -20,6 +20,10 @@ const meta: Meta<typeof ItemIcon> = {
         category: TABLE_CATEGORIES.MUI,
       },
     },
+    type: {
+      control: 'radio',
+      options: ItemType,
+    },
   },
 };
 
@@ -40,17 +44,22 @@ export const Default: Story = {
   },
 };
 
+export const ImageWithStyle: Story = {
+  args: {
+    type: ItemType.FOLDER,
+    iconSrc: 'https://picsum.photos/200/100',
+    size: '100px',
+    sx: {
+      borderRadius: 2,
+    },
+  },
+};
+
 export const Image: Story = {
   args: {
     type: ItemType.S3_FILE,
     color: 'black',
-    extra: {
-      [ItemType.S3_FILE]: {
-        name: '',
-
-        mimetype: MimeTypes.Image.JPEG,
-      },
-    } as S3FileItemExtra,
+    mimetype: MimeTypes.Image.JPEG,
   },
 };
 
@@ -58,11 +67,7 @@ export const Video: Story = {
   args: {
     type: ItemType.S3_FILE,
     color: 'black',
-    extra: {
-      [ItemType.S3_FILE]: {
-        mimetype: MimeTypes.Video.MP4,
-      },
-    } as S3FileItemExtra,
+    mimetype: MimeTypes.Video.MP4,
   },
 };
 
@@ -70,11 +75,7 @@ export const Audio: Story = {
   args: {
     type: ItemType.S3_FILE,
     color: 'black',
-    extra: {
-      [ItemType.S3_FILE]: {
-        mimetype: MimeTypes.Audio.MP3,
-      },
-    } as S3FileItemExtra,
+    mimetype: MimeTypes.Audio.MP3,
   },
 };
 
@@ -82,11 +83,7 @@ export const PDF: Story = {
   args: {
     type: ItemType.S3_FILE,
     color: 'black',
-    extra: {
-      [ItemType.S3_FILE]: {
-        mimetype: MimeTypes.PDF,
-      },
-    } as S3FileItemExtra,
+    mimetype: MimeTypes.PDF,
   },
 };
 
@@ -94,9 +91,47 @@ export const ZIP: Story = {
   args: {
     type: ItemType.S3_FILE,
     color: 'black',
+    mimetype: MimeTypes.ZIP,
+  },
+};
+
+export const App: Story = {
+  args: {
+    type: ItemType.APP,
+    color: 'black',
+  },
+};
+
+export const Link: Story = {
+  args: {
+    type: ItemType.LINK,
+    color: 'black',
+  },
+};
+
+export const Shortcut: Story = {
+  args: {
+    type: ItemType.SHORTCUT,
+    color: 'black',
+  },
+};
+
+export const EtherPad: Story = {
+  args: {
+    type: ItemType.ETHERPAD,
+    color: 'black',
+  },
+};
+
+export const FancyImage: Story = {
+  args: {
+    type: ItemType.S3_FILE,
+    color: 'red',
+    sx: { fontSize: '3rem' },
     extra: {
       [ItemType.S3_FILE]: {
-        mimetype: MimeTypes.ZIP,
+        name: '',
+        mimetype: MimeTypes.Image.JPEG,
       },
     } as S3FileItemExtra,
   },

--- a/src/icons/ItemIcon.tsx
+++ b/src/icons/ItemIcon.tsx
@@ -36,21 +36,18 @@ export interface ItemIconProps {
    * item type
    */
   type: UnionOfConst<typeof ItemType> | 'upload';
+  /**
+   * An HTML Color to usa for the foreground of the icon
+   */
   color?: string;
   /**
-   * item extra
+   * @deprecated Use the `mimetype` prop.
+   * To extract the mimetype from the item extra use the `getMimeType` function exported from @graasp/sdk
+   * Item extra used to define the mimetype
    */
   extra?: LocalFileItemExtra | S3FileItemExtra;
   mimetype?: string;
-  /**
-   * @deprecated use sx
-   * */
-  iconClass?: string;
   iconSrc?: string;
-  /**
-   * @deprecated use alt
-   */
-  name?: string;
   sx?: SxProps;
 }
 
@@ -59,7 +56,6 @@ const ItemIcon: FC<ItemIconProps> = ({
   extra,
   mimetype: defaultMimetype,
   iconSrc,
-  name,
   alt = '',
   sx,
   type,
@@ -73,8 +69,9 @@ const ItemIcon: FC<ItemIconProps> = ({
           // icons should be squared
           maxHeight: ITEM_ICON_MAX_SIZE,
           maxWidth: ITEM_ICON_MAX_SIZE,
+          ...sx,
         }}
-        alt={name ?? alt}
+        alt={alt}
         src={iconSrc}
       />
     );

--- a/src/icons/ItemIcon.tsx
+++ b/src/icons/ItemIcon.tsx
@@ -28,7 +28,7 @@ import {
 import { StyledImage } from '../StyledComponents/StyledBaseComponents';
 import EtherpadIcon from './EtherpadIcon';
 
-const ITEM_ICON_MAX_SIZE = 25;
+const MAX_ICON_SIZE = '25px';
 
 export interface ItemIconProps {
   alt: string;
@@ -42,13 +42,14 @@ export interface ItemIconProps {
   color?: string;
   /**
    * @deprecated Use the `mimetype` prop.
-   * To extract the mimetype from the item extra use the `getMimeType` function exported from @graasp/sdk
+   * To extract the mimetype from the item extra use the `getMimetype` function exported from @graasp/sdk
    * Item extra used to define the mimetype
    */
   extra?: LocalFileItemExtra | S3FileItemExtra;
   mimetype?: string;
   iconSrc?: string;
   sx?: SxProps;
+  size?: string;
 }
 
 const ItemIcon: FC<ItemIconProps> = ({
@@ -58,6 +59,7 @@ const ItemIcon: FC<ItemIconProps> = ({
   iconSrc,
   alt = '',
   sx,
+  size = MAX_ICON_SIZE,
   type,
 }) => {
   const mimetype = extra ? getMimetype(extra) : defaultMimetype;
@@ -67,8 +69,11 @@ const ItemIcon: FC<ItemIconProps> = ({
       <StyledImage
         sx={{
           // icons should be squared
-          maxHeight: ITEM_ICON_MAX_SIZE,
-          maxWidth: ITEM_ICON_MAX_SIZE,
+          maxHeight: size,
+          maxWidth: size,
+          height: size,
+          width: size,
+          objectFit: 'cover',
           ...sx,
         }}
         alt={alt}


### PR DESCRIPTION
In this PR:
- use the `sx` prop passe when displaying the `iconSrc`
- remove deprecated props