### PR TITLE
feat: update buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,856 +4,750 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [4.7.0](https://github.com/graasp/graasp-ui/compare/v4.6.1...v4.7.0) (2024-02-13)
 
-
 ### Features
 
-* use vite to bundle and optimize package ([#567](https://github.com/graasp/graasp-ui/issues/567)) ([6760041](https://github.com/graasp/graasp-ui/commit/6760041316f9e1209f46fc84372155ffe37ebfa5))
-
+- use vite to bundle and optimize package ([#567](https://github.com/graasp/graasp-ui/issues/567)) ([6760041](https://github.com/graasp/graasp-ui/commit/6760041316f9e1209f46fc84372155ffe37ebfa5))
 
 ### Bug Fixes
 
-* use sx prop passed when there is an src ([#689](https://github.com/graasp/graasp-ui/issues/689)) ([84290cb](https://github.com/graasp/graasp-ui/commit/84290cb138b3f56e532c158b853bc83319194bcc))
+- use sx prop passed when there is an src ([#689](https://github.com/graasp/graasp-ui/issues/689)) ([84290cb](https://github.com/graasp/graasp-ui/commit/84290cb138b3f56e532c158b853bc83319194bcc))
 
 ## [4.6.1](https://github.com/graasp/graasp-ui/compare/v4.6.0...v4.6.1) (2024-02-06)
 
-
 ### Bug Fixes
 
-* use given icon component ([#695](https://github.com/graasp/graasp-ui/issues/695)) ([fe18e69](https://github.com/graasp/graasp-ui/commit/fe18e693bb6bab6d9b3c8e1a3e56fdcfef333b80))
+- use given icon component ([#695](https://github.com/graasp/graasp-ui/issues/695)) ([fe18e69](https://github.com/graasp/graasp-ui/commit/fe18e693bb6bab6d9b3c8e1a3e56fdcfef333b80))
 
 ## [4.6.0](https://github.com/graasp/graasp-ui/compare/v4.5.1...v4.6.0) (2024-02-06)
 
-
 ### Features
 
-* navigator render extra item ([#688](https://github.com/graasp/graasp-ui/issues/688)) ([2458c90](https://github.com/graasp/graasp-ui/commit/2458c90c9490b7a3a8f052f05e6edac1c6836356))
-
+- navigator render extra item ([#688](https://github.com/graasp/graasp-ui/issues/688)) ([2458c90](https://github.com/graasp/graasp-ui/commit/2458c90c9490b7a3a8f052f05e6edac1c6836356))
 
 ### Bug Fixes
 
-* update forbiddenContent ([#684](https://github.com/graasp/graasp-ui/issues/684)) ([16d19e3](https://github.com/graasp/graasp-ui/commit/16d19e3d8f7401fa1a1d29fd4c583e1f8cd36b6a))
-* use `overflow: auto` instead of `overflow: scroll` ([#691](https://github.com/graasp/graasp-ui/issues/691)) ([7c9cad1](https://github.com/graasp/graasp-ui/commit/7c9cad1c0072924d234b15622451bfd218fe96e4))
+- update forbiddenContent ([#684](https://github.com/graasp/graasp-ui/issues/684)) ([16d19e3](https://github.com/graasp/graasp-ui/commit/16d19e3d8f7401fa1a1d29fd4c583e1f8cd36b6a))
+- use `overflow: auto` instead of `overflow: scroll` ([#691](https://github.com/graasp/graasp-ui/issues/691)) ([7c9cad1](https://github.com/graasp/graasp-ui/commit/7c9cad1c0072924d234b15622451bfd218fe96e4))
 
 ## [4.5.1](https://github.com/graasp/graasp-ui/compare/v4.5.0...v4.5.1) (2024-02-01)
 
-
 ### Bug Fixes
 
-* open and dismiss menu and add relative position to content wrapper ([#685](https://github.com/graasp/graasp-ui/issues/685)) ([4956584](https://github.com/graasp/graasp-ui/commit/4956584f92472280828663befbaa977c101955fb))
-* update main with flex box ([#682](https://github.com/graasp/graasp-ui/issues/682)) ([fd8ef67](https://github.com/graasp/graasp-ui/commit/fd8ef67475e9bb83fb53bf960b613ea34cbad700))
+- open and dismiss menu and add relative position to content wrapper ([#685](https://github.com/graasp/graasp-ui/issues/685)) ([4956584](https://github.com/graasp/graasp-ui/commit/4956584f92472280828663befbaa977c101955fb))
+- update main with flex box ([#682](https://github.com/graasp/graasp-ui/issues/682)) ([fd8ef67](https://github.com/graasp/graasp-ui/commit/fd8ef67475e9bb83fb53bf960b613ea34cbad700))
 
 ## [4.5.0](https://github.com/graasp/graasp-ui/compare/v4.4.0...v4.5.0) (2024-01-29)
 
-
 ### Features
 
-* add type props to share and edit buttons ([#676](https://github.com/graasp/graasp-ui/issues/676)) ([b7d580a](https://github.com/graasp/graasp-ui/commit/b7d580af710f62fc6f5f88679f771f007aee4d1e))
-* update `Main` component ([#665](https://github.com/graasp/graasp-ui/issues/665)) ([7411a5c](https://github.com/graasp/graasp-ui/commit/7411a5cfdd7104b6974e2b3fc6f0c66ef51f3036))
-
+- add type props to share and edit buttons ([#676](https://github.com/graasp/graasp-ui/issues/676)) ([b7d580a](https://github.com/graasp/graasp-ui/commit/b7d580af710f62fc6f5f88679f771f007aee4d1e))
+- update `Main` component ([#665](https://github.com/graasp/graasp-ui/issues/665)) ([7411a5c](https://github.com/graasp/graasp-ui/commit/7411a5cfdd7104b6974e2b3fc6f0c66ef51f3036))
 
 ### Bug Fixes
 
-* remove memo and dispaly data first ([#677](https://github.com/graasp/graasp-ui/issues/677)) ([b5b46f4](https://github.com/graasp/graasp-ui/commit/b5b46f49ea94958bb36928ae3ba6cf505e7e3e76))
+- remove memo and dispaly data first ([#677](https://github.com/graasp/graasp-ui/issues/677)) ([b5b46f4](https://github.com/graasp/graasp-ui/commit/b5b46f49ea94958bb36928ae3ba6cf505e7e3e76))
 
 ## [4.4.0](https://github.com/graasp/graasp-ui/compare/v4.3.1...v4.4.0) (2024-01-24)
 
-
 ### Features
 
-* create mobile view custom hook ([#667](https://github.com/graasp/graasp-ui/issues/667)) ([16c5c2d](https://github.com/graasp/graasp-ui/commit/16c5c2d0d24d506c7d2267a1847baef56c444394))
-
+- create mobile view custom hook ([#667](https://github.com/graasp/graasp-ui/issues/667)) ([16c5c2d](https://github.com/graasp/graasp-ui/commit/16c5c2d0d24d506c7d2267a1847baef56c444394))
 
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v3.5.0 ([#663](https://github.com/graasp/graasp-ui/issues/663)) ([83896af](https://github.com/graasp/graasp-ui/commit/83896afca652f7d81b31fe3dc0c1492da49ea351))
-* remove qs dependency ([#655](https://github.com/graasp/graasp-ui/issues/655)) ([3692d55](https://github.com/graasp/graasp-ui/commit/3692d557e328f02eb8adfc2d6b1dc9ef4b8e35ff))
+- **deps:** update dependency @graasp/sdk to v3.5.0 ([#663](https://github.com/graasp/graasp-ui/issues/663)) ([83896af](https://github.com/graasp/graasp-ui/commit/83896afca652f7d81b31fe3dc0c1492da49ea351))
+- remove qs dependency ([#655](https://github.com/graasp/graasp-ui/issues/655)) ([3692d55](https://github.com/graasp/graasp-ui/commit/3692d557e328f02eb8adfc2d6b1dc9ef4b8e35ff))
 
 ## [4.3.1](https://github.com/graasp/graasp-ui/compare/v4.3.0...v4.3.1) (2024-01-17)
 
-
 ### Bug Fixes
 
-* add tests for disabled in `Select` ([2f97387](https://github.com/graasp/graasp-ui/commit/2f973876fa555c5b1db3de13c64dba7ec2b29e77))
-* **deps:** update dependency @graasp/sdk to v3.4.1 ([#653](https://github.com/graasp/graasp-ui/issues/653)) ([7a0ce24](https://github.com/graasp/graasp-ui/commit/7a0ce2490e2b6b2ad4f2966c288b305cbc7c943c))
-* disabled prop issues ([#649](https://github.com/graasp/graasp-ui/issues/649)) ([2f97387](https://github.com/graasp/graasp-ui/commit/2f973876fa555c5b1db3de13c64dba7ec2b29e77))
+- add tests for disabled in `Select` ([2f97387](https://github.com/graasp/graasp-ui/commit/2f973876fa555c5b1db3de13c64dba7ec2b29e77))
+- **deps:** update dependency @graasp/sdk to v3.4.1 ([#653](https://github.com/graasp/graasp-ui/issues/653)) ([7a0ce24](https://github.com/graasp/graasp-ui/commit/7a0ce2490e2b6b2ad4f2966c288b305cbc7c943c))
+- disabled prop issues ([#649](https://github.com/graasp/graasp-ui/issues/649)) ([2f97387](https://github.com/graasp/graasp-ui/commit/2f973876fa555c5b1db3de13c64dba7ec2b29e77))
 
 ## [4.3.0](https://github.com/graasp/graasp-ui/compare/v4.2.0...v4.3.0) (2024-01-11)
 
-
 ### Features
 
-* add disable to select options ([#631](https://github.com/graasp/graasp-ui/issues/631)) ([c2dfe20](https://github.com/graasp/graasp-ui/commit/c2dfe20970b85d62fd474fdf7855b2cc82f8633a))
-* add mimetype option in `ItemIcon` ([#644](https://github.com/graasp/graasp-ui/issues/644)) ([0d69052](https://github.com/graasp/graasp-ui/commit/0d690524799cebd1ccf47c8ab993c7091c401545))
-* diable select if all options disabled ([#640](https://github.com/graasp/graasp-ui/issues/640)) ([45f2860](https://github.com/graasp/graasp-ui/commit/45f286084ffb469a36d1cc34902d8d8879447744))
-
+- add disable to select options ([#631](https://github.com/graasp/graasp-ui/issues/631)) ([c2dfe20](https://github.com/graasp/graasp-ui/commit/c2dfe20970b85d62fd474fdf7855b2cc82f8633a))
+- add mimetype option in `ItemIcon` ([#644](https://github.com/graasp/graasp-ui/issues/644)) ([0d69052](https://github.com/graasp/graasp-ui/commit/0d690524799cebd1ccf47c8ab993c7091c401545))
+- diable select if all options disabled ([#640](https://github.com/graasp/graasp-ui/issues/640)) ([45f2860](https://github.com/graasp/graasp-ui/commit/45f286084ffb469a36d1cc34902d8d8879447744))
 
 ### Bug Fixes
 
-* add a disabled prop to the select ([#634](https://github.com/graasp/graasp-ui/issues/634)) ([0ee48eb](https://github.com/graasp/graasp-ui/commit/0ee48eb9ad30e170e52a2e77d34a40f720063020))
+- add a disabled prop to the select ([#634](https://github.com/graasp/graasp-ui/issues/634)) ([0ee48eb](https://github.com/graasp/graasp-ui/commit/0ee48eb9ad30e170e52a2e77d34a40f720063020))
 
 ## [4.2.0](https://github.com/graasp/graasp-ui/compare/v4.1.1...v4.2.0) (2023-12-22)
 
-
 ### Features
 
-* table pagination ([#520](https://github.com/graasp/graasp-ui/issues/520)) ([e38d618](https://github.com/graasp/graasp-ui/commit/e38d61886cd680fa9476c1a755b60cb4e8db5a59))
-
+- table pagination ([#520](https://github.com/graasp/graasp-ui/issues/520)) ([e38d618](https://github.com/graasp/graasp-ui/commit/e38d61886cd680fa9476c1a755b60cb4e8db5a59))
 
 ### Bug Fixes
 
-* udpate release-please condition ([5ca2a7e](https://github.com/graasp/graasp-ui/commit/5ca2a7e0788425a17145250392a13a74b2304d47))
+- udpate release-please condition ([5ca2a7e](https://github.com/graasp/graasp-ui/commit/5ca2a7e0788425a17145250392a13a74b2304d47))
 
 ## [4.1.1](https://github.com/graasp/graasp-ui/compare/v4.1.0...v4.1.1) (2023-12-04)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v3.3.0 ([#610](https://github.com/graasp/graasp-ui/issues/610)) ([82722a9](https://github.com/graasp/graasp-ui/commit/82722a9c20ca659d85ee39bd4a43a1a2f2d37345))
+- **deps:** update dependency @graasp/sdk to v3.3.0 ([#610](https://github.com/graasp/graasp-ui/issues/610)) ([82722a9](https://github.com/graasp/graasp-ui/commit/82722a9c20ca659d85ee39bd4a43a1a2f2d37345))
 
 ## [4.1.0](https://github.com/graasp/graasp-ui/compare/v4.0.1...v4.1.0) (2023-11-16)
 
-
 ### Features
 
-* add onClick for Link, File and DownloadFileButton ([#549](https://github.com/graasp/graasp-ui/issues/549)) ([a212d92](https://github.com/graasp/graasp-ui/commit/a212d920c12954142a9d6ac972cf6d05bc793893))
-
+- add onClick for Link, File and DownloadFileButton ([#549](https://github.com/graasp/graasp-ui/issues/549)) ([a212d92](https://github.com/graasp/graasp-ui/commit/a212d920c12954142a9d6ac972cf6d05bc793893))
 
 ### Bug Fixes
 
-* support WebP format ([#603](https://github.com/graasp/graasp-ui/issues/603)) ([cd4e6ad](https://github.com/graasp/graasp-ui/commit/cd4e6ad5cb818370874702042b12dd07e1421834))
+- support WebP format ([#603](https://github.com/graasp/graasp-ui/issues/603)) ([cd4e6ad](https://github.com/graasp/graasp-ui/commit/cd4e6ad5cb818370874702042b12dd07e1421834))
 
 ## [4.0.1](https://github.com/graasp/graasp-ui/compare/v4.0.0...v4.0.1) (2023-11-13)
 
-
 ### Bug Fixes
 
-* allow better typing for Context enum and add color for account ([#584](https://github.com/graasp/graasp-ui/issues/584)) ([db40c6a](https://github.com/graasp/graasp-ui/commit/db40c6ab281166715b261dcc4842840b82b4bfbb))
-* **deps:** update dependency @graasp/sdk to v2.0.1 ([#577](https://github.com/graasp/graasp-ui/issues/577)) ([1041814](https://github.com/graasp/graasp-ui/commit/1041814b4dfa9516ff9ba6da50fe7c3c8d8d90cf))
-* **deps:** update dependency react-cookie-consent to v9 ([#560](https://github.com/graasp/graasp-ui/issues/560)) ([e9bf4c1](https://github.com/graasp/graasp-ui/commit/e9bf4c11c87e02dc1e2d6172161d98a842862022))
+- allow better typing for Context enum and add color for account ([#584](https://github.com/graasp/graasp-ui/issues/584)) ([db40c6a](https://github.com/graasp/graasp-ui/commit/db40c6ab281166715b261dcc4842840b82b4bfbb))
+- **deps:** update dependency @graasp/sdk to v2.0.1 ([#577](https://github.com/graasp/graasp-ui/issues/577)) ([1041814](https://github.com/graasp/graasp-ui/commit/1041814b4dfa9516ff9ba6da50fe7c3c8d8d90cf))
+- **deps:** update dependency react-cookie-consent to v9 ([#560](https://github.com/graasp/graasp-ui/issues/560)) ([e9bf4c1](https://github.com/graasp/graasp-ui/commit/e9bf4c11c87e02dc1e2d6172161d98a842862022))
 
 ## [4.0.0](https://github.com/graasp/graasp-ui/compare/v3.7.0...v4.0.0) (2023-11-03)
 
-
 ### ⚠ BREAKING CHANGES
 
-* remove immutable ([#568](https://github.com/graasp/graasp-ui/issues/568))
+- remove immutable ([#568](https://github.com/graasp/graasp-ui/issues/568))
 
 ### Features
 
-* remove immutable ([#568](https://github.com/graasp/graasp-ui/issues/568)) ([ee77ad8](https://github.com/graasp/graasp-ui/commit/ee77ad8a524541fae0216bcc7724a245decc965b))
-
+- remove immutable ([#568](https://github.com/graasp/graasp-ui/issues/568)) ([ee77ad8](https://github.com/graasp/graasp-ui/commit/ee77ad8a524541fae0216bcc7724a245decc965b))
 
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.10.1 ([#556](https://github.com/graasp/graasp-ui/issues/556)) ([47d800e](https://github.com/graasp/graasp-ui/commit/47d800e7884d6141150ca1322e78304a580a63c1))
+- **deps:** update dependency @graasp/sdk to v1.10.1 ([#556](https://github.com/graasp/graasp-ui/issues/556)) ([47d800e](https://github.com/graasp/graasp-ui/commit/47d800e7884d6141150ca1322e78304a580a63c1))
 
 ## [3.7.0](https://github.com/graasp/graasp-ui/compare/v3.6.1...v3.7.0) (2023-10-26)
 
-
 ### Features
 
-* add custom profile option to user dropdown ([#550](https://github.com/graasp/graasp-ui/issues/550)) ([167b6e8](https://github.com/graasp/graasp-ui/commit/167b6e82b8cf674010b4104d224dec212a58b9a1))
-
+- add custom profile option to user dropdown ([#550](https://github.com/graasp/graasp-ui/issues/550)) ([167b6e8](https://github.com/graasp/graasp-ui/commit/167b6e82b8cf674010b4104d224dec212a58b9a1))
 
 ### Bug Fixes
 
-* update yarn and remove mdx-js/react dep ([#565](https://github.com/graasp/graasp-ui/issues/565)) ([ee0acf9](https://github.com/graasp/graasp-ui/commit/ee0acf94c9cdd6c1851290bdcbdceedc59ee5a32))
+- update yarn and remove mdx-js/react dep ([#565](https://github.com/graasp/graasp-ui/issues/565)) ([ee0acf9](https://github.com/graasp/graasp-ui/commit/ee0acf94c9cdd6c1851290bdcbdceedc59ee5a32))
 
 ## [3.6.1](https://github.com/graasp/graasp-ui/compare/v3.6.0...v3.6.1) (2023-10-24)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency katex to v0.16.9 ([#541](https://github.com/graasp/graasp-ui/issues/541)) ([ea467e7](https://github.com/graasp/graasp-ui/commit/ea467e7f2ee14561aa2a1a885c3928e4d4843dcb))
-* return undefined when no uuid and add upload icon ([#553](https://github.com/graasp/graasp-ui/issues/553)) ([de9f270](https://github.com/graasp/graasp-ui/commit/de9f2706cf40f2ca6aa545d346ec98dc0809c7ab))
+- **deps:** update dependency katex to v0.16.9 ([#541](https://github.com/graasp/graasp-ui/issues/541)) ([ea467e7](https://github.com/graasp/graasp-ui/commit/ea467e7f2ee14561aa2a1a885c3928e4d4843dcb))
+- return undefined when no uuid and add upload icon ([#553](https://github.com/graasp/graasp-ui/issues/553)) ([de9f270](https://github.com/graasp/graasp-ui/commit/de9f2706cf40f2ca6aa545d346ec98dc0809c7ab))
 
 ## [3.6.0](https://github.com/graasp/graasp-ui/compare/v3.5.4...v3.6.0) (2023-10-20)
 
-
 ### Features
 
-* add value to select component ([#548](https://github.com/graasp/graasp-ui/issues/548)) ([5698e4a](https://github.com/graasp/graasp-ui/commit/5698e4a7dde3ce40179615f9602dd7801acf95e4))
+- add value to select component ([#548](https://github.com/graasp/graasp-ui/issues/548)) ([5698e4a](https://github.com/graasp/graasp-ui/commit/5698e4a7dde3ce40179615f9602dd7801acf95e4))
 
 ## [3.5.4](https://github.com/graasp/graasp-ui/compare/v3.5.3...v3.5.4) (2023-10-04)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.7.0 and immutablejs to v4.3.4 ([#535](https://github.com/graasp/graasp-ui/issues/535)) ([8054cd6](https://github.com/graasp/graasp-ui/commit/8054cd684f6d92623a88f6466a752f38c1f4920d))
+- **deps:** update dependency @graasp/sdk to v1.7.0 and immutablejs to v4.3.4 ([#535](https://github.com/graasp/graasp-ui/issues/535)) ([8054cd6](https://github.com/graasp/graasp-ui/commit/8054cd684f6d92623a88f6466a752f38c1f4920d))
 
 ## [3.5.3](https://github.com/graasp/graasp-ui/compare/v3.5.2...v3.5.3) (2023-09-30)
 
-
 ### Bug Fixes
 
-* add tests and re-enable jest unit test in workflow and locally ([2b67d73](https://github.com/graasp/graasp-ui/commit/2b67d7377fdac82bc0e780e3d716ec31c0f64531))
-* **deps:** update dependency http-status-codes to v2.3.0 ([#526](https://github.com/graasp/graasp-ui/issues/526)) ([0af10aa](https://github.com/graasp/graasp-ui/commit/0af10aaf9475ac4efb5e37e760779e0c17f56695))
-* **deps:** update dependency uuid to v9.0.1 ([de2e487](https://github.com/graasp/graasp-ui/commit/de2e4871d6cf3edccdea82ce86c88804a265282a))
-* improve getUUID and add tests ([#533](https://github.com/graasp/graasp-ui/issues/533)) ([2b67d73](https://github.com/graasp/graasp-ui/commit/2b67d7377fdac82bc0e780e3d716ec31c0f64531))
+- add tests and re-enable jest unit test in workflow and locally ([2b67d73](https://github.com/graasp/graasp-ui/commit/2b67d7377fdac82bc0e780e3d716ec31c0f64531))
+- **deps:** update dependency http-status-codes to v2.3.0 ([#526](https://github.com/graasp/graasp-ui/issues/526)) ([0af10aa](https://github.com/graasp/graasp-ui/commit/0af10aaf9475ac4efb5e37e760779e0c17f56695))
+- **deps:** update dependency uuid to v9.0.1 ([de2e487](https://github.com/graasp/graasp-ui/commit/de2e4871d6cf3edccdea82ce86c88804a265282a))
+- improve getUUID and add tests ([#533](https://github.com/graasp/graasp-ui/issues/533)) ([2b67d73](https://github.com/graasp/graasp-ui/commit/2b67d7377fdac82bc0e780e3d716ec31c0f64531))
 
 ## [3.5.2](https://github.com/graasp/graasp-ui/compare/v3.5.1...v3.5.2) (2023-09-27)
 
-
 ### Bug Fixes
 
-* remove signOut prop ([#530](https://github.com/graasp/graasp-ui/issues/530)) ([c30a5b9](https://github.com/graasp/graasp-ui/commit/c30a5b9938bd6168f3f33ac37190c1d9397cb773))
+- remove signOut prop ([#530](https://github.com/graasp/graasp-ui/issues/530)) ([c30a5b9](https://github.com/graasp/graasp-ui/commit/c30a5b9938bd6168f3f33ac37190c1d9397cb773))
 
 ## [3.5.1](https://github.com/graasp/graasp-ui/compare/v3.5.0...v3.5.1) (2023-09-25)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.6.0 ([#525](https://github.com/graasp/graasp-ui/issues/525)) ([c2233d0](https://github.com/graasp/graasp-ui/commit/c2233d02e5403175c87cee0e39c56b8eecbe4de4))
+- **deps:** update dependency @graasp/sdk to v1.6.0 ([#525](https://github.com/graasp/graasp-ui/issues/525)) ([c2233d0](https://github.com/graasp/graasp-ui/commit/c2233d02e5403175c87cee0e39c56b8eecbe4de4))
 
 ## [3.5.0](https://github.com/graasp/graasp-ui/compare/v3.4.0...v3.5.0) (2023-09-22)
 
-
 ### Features
 
-* custom hook to get uuid url params ([#517](https://github.com/graasp/graasp-ui/issues/517)) ([cd2716d](https://github.com/graasp/graasp-ui/commit/cd2716d7ec9b204b1ca80a759627785112cb61b7))
-
+- custom hook to get uuid url params ([#517](https://github.com/graasp/graasp-ui/issues/517)) ([cd2716d](https://github.com/graasp/graasp-ui/commit/cd2716d7ec9b204b1ca80a759627785112cb61b7))
 
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.5.0 ([#513](https://github.com/graasp/graasp-ui/issues/513)) ([4b69501](https://github.com/graasp/graasp-ui/commit/4b69501dd9bb75ed92ded2e45b4b7f07f136c700))
+- **deps:** update dependency @graasp/sdk to v1.5.0 ([#513](https://github.com/graasp/graasp-ui/issues/513)) ([4b69501](https://github.com/graasp/graasp-ui/commit/4b69501dd9bb75ed92ded2e45b4b7f07f136c700))
 
 ## [3.4.0](https://github.com/graasp/graasp-ui/compare/v3.3.2...v3.4.0) (2023-09-01)
 
-
 ### Features
 
-* add resize wrapper to item files ([#505](https://github.com/graasp/graasp-ui/issues/505)) ([687113c](https://github.com/graasp/graasp-ui/commit/687113c866f0d3c4c5ed24dfac7672365b2a7893))
+- add resize wrapper to item files ([#505](https://github.com/graasp/graasp-ui/issues/505)) ([687113c](https://github.com/graasp/graasp-ui/commit/687113c866f0d3c4c5ed24dfac7672365b2a7893))
 
 ## [3.3.2](https://github.com/graasp/graasp-ui/compare/v3.3.1...v3.3.2) (2023-08-18)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.2.0 ([#480](https://github.com/graasp/graasp-ui/issues/480)) ([07a22a0](https://github.com/graasp/graasp-ui/commit/07a22a0137c7d7f608171d94d364cda7851547da))
-* **deps:** update dependency immutable to v4.3.2 ([#470](https://github.com/graasp/graasp-ui/issues/470)) ([c942760](https://github.com/graasp/graasp-ui/commit/c9427609af772bbfc26376549d17ac5ffcebd263))
+- **deps:** update dependency @graasp/sdk to v1.2.0 ([#480](https://github.com/graasp/graasp-ui/issues/480)) ([07a22a0](https://github.com/graasp/graasp-ui/commit/07a22a0137c7d7f608171d94d364cda7851547da))
+- **deps:** update dependency immutable to v4.3.2 ([#470](https://github.com/graasp/graasp-ui/issues/470)) ([c942760](https://github.com/graasp/graasp-ui/commit/c9427609af772bbfc26376549d17ac5ffcebd263))
 
 ## [3.3.1](https://github.com/graasp/graasp-ui/compare/v3.3.0...v3.3.1) (2023-08-10)
 
-
 ### Bug Fixes
 
-* update analytics url for platform switch ([#482](https://github.com/graasp/graasp-ui/issues/482)) ([431951c](https://github.com/graasp/graasp-ui/commit/431951cd0000a470d82f862d08a7b2e8129a78a6))
+- update analytics url for platform switch ([#482](https://github.com/graasp/graasp-ui/issues/482)) ([431951c](https://github.com/graasp/graasp-ui/commit/431951cd0000a470d82f862d08a7b2e8129a78a6))
 
 ## [3.3.0](https://github.com/graasp/graasp-ui/compare/v3.2.7...v3.3.0) (2023-08-07)
 
-
 ### Features
 
-* add ThemeContext with rtl support ([#473](https://github.com/graasp/graasp-ui/issues/473)) ([99f38f8](https://github.com/graasp/graasp-ui/commit/99f38f8b9d58391e01c222d3ec887458d0f48bad))
-
+- add ThemeContext with rtl support ([#473](https://github.com/graasp/graasp-ui/issues/473)) ([99f38f8](https://github.com/graasp/graasp-ui/commit/99f38f8b9d58391e01c222d3ec887458d0f48bad))
 
 ### Bug Fixes
 
-* upgrade prettier ([#471](https://github.com/graasp/graasp-ui/issues/471)) ([d9bfec7](https://github.com/graasp/graasp-ui/commit/d9bfec7dba13df24075f734365bde20e709c4588))
+- upgrade prettier ([#471](https://github.com/graasp/graasp-ui/issues/471)) ([d9bfec7](https://github.com/graasp/graasp-ui/commit/d9bfec7dba13df24075f734365bde20e709c4588))
 
 ## [3.2.7](https://github.com/graasp/graasp-ui/compare/v3.2.6...v3.2.7) (2023-07-31)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency clsx to v2 ([#439](https://github.com/graasp/graasp-ui/issues/439)) ([cc2fd3e](https://github.com/graasp/graasp-ui/commit/cc2fd3eeb394c8eae4e906900076b90e037c4374))
-* zIndex on quill tooltip ([#460](https://github.com/graasp/graasp-ui/issues/460)) ([34b1da6](https://github.com/graasp/graasp-ui/commit/34b1da64c6ddaf0d81b8ab63a7a99c36cd32a538))
+- **deps:** update dependency clsx to v2 ([#439](https://github.com/graasp/graasp-ui/issues/439)) ([cc2fd3e](https://github.com/graasp/graasp-ui/commit/cc2fd3eeb394c8eae4e906900076b90e037c4374))
+- zIndex on quill tooltip ([#460](https://github.com/graasp/graasp-ui/issues/460)) ([34b1da6](https://github.com/graasp/graasp-ui/commit/34b1da64c6ddaf0d81b8ab63a7a99c36cd32a538))
 
 ## [3.2.6](https://github.com/graasp/graasp-ui/compare/v3.2.5...v3.2.6) (2023-07-26)
 
-
 ### Bug Fixes
 
-* link button ([#458](https://github.com/graasp/graasp-ui/issues/458)) ([9f20e15](https://github.com/graasp/graasp-ui/commit/9f20e15861e87b9b630cbff5af259bc2f806ebfb))
-* **ui/style:** miniature magnifying glass in builder  ([#456](https://github.com/graasp/graasp-ui/issues/456)) ([15ba98b](https://github.com/graasp/graasp-ui/commit/15ba98b21e7a2371c7dcdb4791c322d3bb843a09))
+- link button ([#458](https://github.com/graasp/graasp-ui/issues/458)) ([9f20e15](https://github.com/graasp/graasp-ui/commit/9f20e15861e87b9b630cbff5af259bc2f806ebfb))
+- **ui/style:** miniature magnifying glass in builder ([#456](https://github.com/graasp/graasp-ui/issues/456)) ([15ba98b](https://github.com/graasp/graasp-ui/commit/15ba98b21e7a2371c7dcdb4791c322d3bb843a09))
 
 ## [3.2.5](https://github.com/graasp/graasp-ui/compare/v3.2.4...v3.2.5) (2023-07-21)
 
-
 ### Bug Fixes
 
-* add title and use real link instead of js redirect ([#452](https://github.com/graasp/graasp-ui/issues/452)) ([b16d05b](https://github.com/graasp/graasp-ui/commit/b16d05bddc82faba84d08e6004e2e2a3752956bb))
-* **deps:** update dependency @graasp/sdk to v1.1.3 ([#446](https://github.com/graasp/graasp-ui/issues/446)) ([919e78f](https://github.com/graasp/graasp-ui/commit/919e78f04fb561a9bceb99ff672a370242c047f1))
-* fill-rule issue ([#451](https://github.com/graasp/graasp-ui/issues/451)) ([63100d7](https://github.com/graasp/graasp-ui/commit/63100d7ed389c817c2a88b07f753492a0880ef93))
+- add title and use real link instead of js redirect ([#452](https://github.com/graasp/graasp-ui/issues/452)) ([b16d05b](https://github.com/graasp/graasp-ui/commit/b16d05bddc82faba84d08e6004e2e2a3752956bb))
+- **deps:** update dependency @graasp/sdk to v1.1.3 ([#446](https://github.com/graasp/graasp-ui/issues/446)) ([919e78f](https://github.com/graasp/graasp-ui/commit/919e78f04fb561a9bceb99ff672a370242c047f1))
+- fill-rule issue ([#451](https://github.com/graasp/graasp-ui/issues/451)) ([63100d7](https://github.com/graasp/graasp-ui/commit/63100d7ed389c817c2a88b07f753492a0880ef93))
 
 ## [3.2.4](https://github.com/graasp/graasp-ui/compare/v3.2.3...v3.2.4) (2023-07-18)
 
-
 ### Bug Fixes
 
-* show sign out in user switch ([#441](https://github.com/graasp/graasp-ui/issues/441)) ([6727c3a](https://github.com/graasp/graasp-ui/commit/6727c3a2de47df10d83bbeca1ed5a33ecac74caa))
+- show sign out in user switch ([#441](https://github.com/graasp/graasp-ui/issues/441)) ([6727c3a](https://github.com/graasp/graasp-ui/commit/6727c3a2de47df10d83bbeca1ed5a33ecac74caa))
 
 ## [3.2.3](https://github.com/graasp/graasp-ui/compare/v3.2.2...v3.2.3) (2023-07-12)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.1.2 ([#433](https://github.com/graasp/graasp-ui/issues/433)) ([1c602e8](https://github.com/graasp/graasp-ui/commit/1c602e8dd4e68cd6b526b87aa8209e944be9f542))
-* **deps:** update dependency react-cookie-consent to v8 ([#412](https://github.com/graasp/graasp-ui/issues/412)) ([5199b18](https://github.com/graasp/graasp-ui/commit/5199b1897e929cd37ac2811dccf7b71a2fbefd3a))
-* replace `output` by `fileName` in rollup-plugin-scss options ([#423](https://github.com/graasp/graasp-ui/issues/423)) ([1ec596e](https://github.com/graasp/graasp-ui/commit/1ec596e7570d961ed4379e81b9140c932d98f7a2))
+- **deps:** update dependency @graasp/sdk to v1.1.2 ([#433](https://github.com/graasp/graasp-ui/issues/433)) ([1c602e8](https://github.com/graasp/graasp-ui/commit/1c602e8dd4e68cd6b526b87aa8209e944be9f542))
+- **deps:** update dependency react-cookie-consent to v8 ([#412](https://github.com/graasp/graasp-ui/issues/412)) ([5199b18](https://github.com/graasp/graasp-ui/commit/5199b1897e929cd37ac2811dccf7b71a2fbefd3a))
+- replace `output` by `fileName` in rollup-plugin-scss options ([#423](https://github.com/graasp/graasp-ui/issues/423)) ([1ec596e](https://github.com/graasp/graasp-ui/commit/1ec596e7570d961ed4379e81b9140c932d98f7a2))
 
 ## [3.2.2](https://github.com/graasp/graasp-ui/compare/v3.2.1...v3.2.2) (2023-07-10)
 
-
 ### Bug Fixes
 
-* **a11y:** use item name when alttext is falsy ([#415](https://github.com/graasp/graasp-ui/issues/415)) ([32ee9e8](https://github.com/graasp/graasp-ui/commit/32ee9e80baf0fbe4c89e42791db259de49d55dbf))
+- **a11y:** use item name when alttext is falsy ([#415](https://github.com/graasp/graasp-ui/issues/415)) ([32ee9e8](https://github.com/graasp/graasp-ui/commit/32ee9e80baf0fbe4c89e42791db259de49d55dbf))
 
 ## [3.2.1](https://github.com/graasp/graasp-ui/compare/v3.2.0...v3.2.1) (2023-06-29)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.1.1 ([#400](https://github.com/graasp/graasp-ui/issues/400)) ([2c1da3b](https://github.com/graasp/graasp-ui/commit/2c1da3bdbb319589aced05be5926b0a8c4c4a8d0))
-* **deps:** update dependency katex to v0.16.8 ([0b67e36](https://github.com/graasp/graasp-ui/commit/0b67e36ef0dc8260421d1b8a88b850fa25331435))
-* **deps:** update dependency react-cookie-consent to v7.6.0 ([#388](https://github.com/graasp/graasp-ui/issues/388)) ([47af96a](https://github.com/graasp/graasp-ui/commit/47af96a10e94a5ae76c2d99aca147ebf1bf68cee))
-* InputLoginScreen, storybook `subcomponent` and update devdependencies (non-major) (minor) ([#383](https://github.com/graasp/graasp-ui/issues/383)) ([892694e](https://github.com/graasp/graasp-ui/commit/892694ef582cc88351335bff35fcbd5d46ced3b7))
-* mimetype is undefined when items are immutable ([#399](https://github.com/graasp/graasp-ui/issues/399)) ([129f128](https://github.com/graasp/graasp-ui/commit/129f12886a1292b0514e0603dacdefb8313ef29b))
+- **deps:** update dependency @graasp/sdk to v1.1.1 ([#400](https://github.com/graasp/graasp-ui/issues/400)) ([2c1da3b](https://github.com/graasp/graasp-ui/commit/2c1da3bdbb319589aced05be5926b0a8c4c4a8d0))
+- **deps:** update dependency katex to v0.16.8 ([0b67e36](https://github.com/graasp/graasp-ui/commit/0b67e36ef0dc8260421d1b8a88b850fa25331435))
+- **deps:** update dependency react-cookie-consent to v7.6.0 ([#388](https://github.com/graasp/graasp-ui/issues/388)) ([47af96a](https://github.com/graasp/graasp-ui/commit/47af96a10e94a5ae76c2d99aca147ebf1bf68cee))
+- InputLoginScreen, storybook `subcomponent` and update devdependencies (non-major) (minor) ([#383](https://github.com/graasp/graasp-ui/issues/383)) ([892694e](https://github.com/graasp/graasp-ui/commit/892694ef582cc88351335bff35fcbd5d46ced3b7))
+- mimetype is undefined when items are immutable ([#399](https://github.com/graasp/graasp-ui/issues/399)) ([129f128](https://github.com/graasp/graasp-ui/commit/129f12886a1292b0514e0603dacdefb8313ef29b))
 
 ## [3.2.0](https://github.com/graasp/graasp-ui/compare/v3.1.0...v3.2.0) (2023-06-26)
 
-
 ### Features
 
-* makes altText changable for images in FileItem ([#356](https://github.com/graasp/graasp-ui/issues/356)) ([ff34701](https://github.com/graasp/graasp-ui/commit/ff34701b6908b8a38ddeb60f87ad9e90ef072b24))
+- makes altText changable for images in FileItem ([#356](https://github.com/graasp/graasp-ui/issues/356)) ([ff34701](https://github.com/graasp/graasp-ui/commit/ff34701b6908b8a38ddeb60f87ad9e90ef072b24))
 
 ## [3.1.0](https://github.com/graasp/graasp-ui/compare/v3.0.0...v3.1.0) (2023-06-26)
 
-
 ### Features
 
-* add breadcrumb navigation ([#368](https://github.com/graasp/graasp-ui/issues/368)) ([7d03ac9](https://github.com/graasp/graasp-ui/commit/7d03ac975aa6c290790fd2f1c704187db8f13e5d))
-
+- add breadcrumb navigation ([#368](https://github.com/graasp/graasp-ui/issues/368)) ([7d03ac9](https://github.com/graasp/graasp-ui/commit/7d03ac975aa6c290790fd2f1c704187db8f13e5d))
 
 ### Bug Fixes
 
-* **deps:** update dependency @graasp/sdk to v1.0.0 ([7322c8e](https://github.com/graasp/graasp-ui/commit/7322c8e4b321ca35d22d7e2fbf75a62f8266b9a5))
+- **deps:** update dependency @graasp/sdk to v1.0.0 ([7322c8e](https://github.com/graasp/graasp-ui/commit/7322c8e4b321ca35d22d7e2fbf75a62f8266b9a5))
 
 ## [3.0.0](https://github.com/graasp/graasp-ui/compare/v3.0.0-rc.2...v3.0.0) (2023-06-21)
 
-
 ### Features
 
-* **a11y:** add role to userSwitchButton ([#363](https://github.com/graasp/graasp-ui/issues/363)) ([807d7f0](https://github.com/graasp/graasp-ui/commit/807d7f0fbb52e6081e05191ae0a9dca244f77758))
-* sets aria-disabled on disabled links in platform switch ([7b82abd](https://github.com/graasp/graasp-ui/commit/7b82abd598684af0cacf9104ff88c01526ca279a))
-
+- **a11y:** add role to userSwitchButton ([#363](https://github.com/graasp/graasp-ui/issues/363)) ([807d7f0](https://github.com/graasp/graasp-ui/commit/807d7f0fbb52e6081e05191ae0a9dca244f77758))
+- sets aria-disabled on disabled links in platform switch ([7b82abd](https://github.com/graasp/graasp-ui/commit/7b82abd598684af0cacf9104ff88c01526ca279a))
 
 ### Bug Fixes
 
-* **deps:** revert react-quill to 2.0.0-beta.4 ([#370](https://github.com/graasp/graasp-ui/issues/370)) ([c3e8282](https://github.com/graasp/graasp-ui/commit/c3e828258843a3607b360b8dbd9bc9c8a8fdb6bf))
-
+- **deps:** revert react-quill to 2.0.0-beta.4 ([#370](https://github.com/graasp/graasp-ui/issues/370)) ([c3e8282](https://github.com/graasp/graasp-ui/commit/c3e828258843a3607b360b8dbd9bc9c8a8fdb6bf))
 
 ### chore
 
-* **releases:** release 3.0.0 ([bfb125b](https://github.com/graasp/graasp-ui/commit/bfb125bf274ad04db95f355c59f62a786de4d72c))
+- **releases:** release 3.0.0 ([bfb125b](https://github.com/graasp/graasp-ui/commit/bfb125bf274ad04db95f355c59f62a786de4d72c))
 
 ## [3.0.0-rc.2](https://github.com/graasp/graasp-ui/compare/v3.0.0-rc1...v3.0.0-rc.2) (2023-05-31)
 
-
 ### Features
 
-* adds type to button ([#361](https://github.com/graasp/graasp-ui/issues/361)) ([64a4646](https://github.com/graasp/graasp-ui/commit/64a464652834469cb57b3846a1ad76bf7e6adf71))
-
+- adds type to button ([#361](https://github.com/graasp/graasp-ui/issues/361)) ([64a4646](https://github.com/graasp/graasp-ui/commit/64a464652834469cb57b3846a1ad76bf7e6adf71))
 
 ### Bug Fixes
 
-* storybook build command in storybook build workflow ([#358](https://github.com/graasp/graasp-ui/issues/358)) ([d6c999e](https://github.com/graasp/graasp-ui/commit/d6c999eee1c90b002d101def14cdd96d01ff3488))
+- storybook build command in storybook build workflow ([#358](https://github.com/graasp/graasp-ui/issues/358)) ([d6c999e](https://github.com/graasp/graasp-ui/commit/d6c999eee1c90b002d101def14cdd96d01ff3488))
 
 ## [3.0.0-rc1](https://github.com/graasp/graasp-ui/compare/v2.5.0...v3.0.0-rc1) (2023-05-30)
 
-
 ### ⚠ BREAKING CHANGES
 
-* typeorm ([#298](https://github.com/graasp/graasp-ui/issues/298))
+- typeorm ([#298](https://github.com/graasp/graasp-ui/issues/298))
 
 ### Features
 
-* typeorm ([#298](https://github.com/graasp/graasp-ui/issues/298)) ([655d9b1](https://github.com/graasp/graasp-ui/commit/655d9b1b11353e1364c6137d9bd7be994e5ad003))
+- typeorm ([#298](https://github.com/graasp/graasp-ui/issues/298)) ([655d9b1](https://github.com/graasp/graasp-ui/commit/655d9b1b11353e1364c6137d9bd7be994e5ad003))
 
 ## [2.5.0](https://github.com/graasp/graasp-ui/compare/v2.4.3...v2.5.0) (2023-05-08)
 
-
 ### Features
 
-* add creative commons ([#281](https://github.com/graasp/graasp-ui/issues/281)) ([0fc9a0f](https://github.com/graasp/graasp-ui/commit/0fc9a0fabafa11842b88b3a5466982e154148d4e))
-* add tooltips to platform switch buttons ([#340](https://github.com/graasp/graasp-ui/issues/340)) ([a8fb6c0](https://github.com/graasp/graasp-ui/commit/a8fb6c0ba42c7cc8914a968cc37bb80d778baa36))
-
+- add creative commons ([#281](https://github.com/graasp/graasp-ui/issues/281)) ([0fc9a0f](https://github.com/graasp/graasp-ui/commit/0fc9a0fabafa11842b88b3a5466982e154148d4e))
+- add tooltips to platform switch buttons ([#340](https://github.com/graasp/graasp-ui/issues/340)) ([a8fb6c0](https://github.com/graasp/graasp-ui/commit/a8fb6c0ba42c7cc8914a968cc37bb80d778baa36))
 
 ### Bug Fixes
 
-* add constraint for custom cell renderers ([#351](https://github.com/graasp/graasp-ui/issues/351)) ([15d1952](https://github.com/graasp/graasp-ui/commit/15d195272fbd7cfa054746614315b037d6695f99))
-* render platform switch button as link, redirect to library home ([#349](https://github.com/graasp/graasp-ui/issues/349)) ([6020dc9](https://github.com/graasp/graasp-ui/commit/6020dc922a257888efbe7fd8a4487a236c57da62))
+- add constraint for custom cell renderers ([#351](https://github.com/graasp/graasp-ui/issues/351)) ([15d1952](https://github.com/graasp/graasp-ui/commit/15d195272fbd7cfa054746614315b037d6695f99))
+- render platform switch button as link, redirect to library home ([#349](https://github.com/graasp/graasp-ui/issues/349)) ([6020dc9](https://github.com/graasp/graasp-ui/commit/6020dc922a257888efbe7fd8a4487a236c57da62))
 
 ## [2.5.0](https://github.com/graasp/graasp-ui/compare/v2.4.3...v2.5.0) (2023-05-08)
 
-
 ### Features
 
-* add creative commons ([#281](https://github.com/graasp/graasp-ui/issues/281)) ([0fc9a0f](https://github.com/graasp/graasp-ui/commit/0fc9a0fabafa11842b88b3a5466982e154148d4e))
-* add tooltips to platform switch buttons ([#340](https://github.com/graasp/graasp-ui/issues/340)) ([a8fb6c0](https://github.com/graasp/graasp-ui/commit/a8fb6c0ba42c7cc8914a968cc37bb80d778baa36))
-
+- add creative commons ([#281](https://github.com/graasp/graasp-ui/issues/281)) ([0fc9a0f](https://github.com/graasp/graasp-ui/commit/0fc9a0fabafa11842b88b3a5466982e154148d4e))
+- add tooltips to platform switch buttons ([#340](https://github.com/graasp/graasp-ui/issues/340)) ([a8fb6c0](https://github.com/graasp/graasp-ui/commit/a8fb6c0ba42c7cc8914a968cc37bb80d778baa36))
 
 ### Bug Fixes
 
-* add constraint for custom cell renderers ([#351](https://github.com/graasp/graasp-ui/issues/351)) ([15d1952](https://github.com/graasp/graasp-ui/commit/15d195272fbd7cfa054746614315b037d6695f99))
-* render platform switch button as link, redirect to library home ([#349](https://github.com/graasp/graasp-ui/issues/349)) ([6020dc9](https://github.com/graasp/graasp-ui/commit/6020dc922a257888efbe7fd8a4487a236c57da62))
+- add constraint for custom cell renderers ([#351](https://github.com/graasp/graasp-ui/issues/351)) ([15d1952](https://github.com/graasp/graasp-ui/commit/15d195272fbd7cfa054746614315b037d6695f99))
+- render platform switch button as link, redirect to library home ([#349](https://github.com/graasp/graasp-ui/issues/349)) ([6020dc9](https://github.com/graasp/graasp-ui/commit/6020dc922a257888efbe7fd8a4487a236c57da62))
 
 ## [2.4.3](https://github.com/graasp/graasp-ui/compare/v2.4.2...v2.4.3) (2023-05-05)
 
-
 ### Bug Fixes
 
-* use precise item type in DocumentItem given showCollapse ([#342](https://github.com/graasp/graasp-ui/issues/342)) ([b5a12e3](https://github.com/graasp/graasp-ui/commit/b5a12e30cccfb6383a762129d96cac399f64d11b))
+- use precise item type in DocumentItem given showCollapse ([#342](https://github.com/graasp/graasp-ui/issues/342)) ([b5a12e3](https://github.com/graasp/graasp-ui/commit/b5a12e30cccfb6383a762129d96cac399f64d11b))
 
 ## [2.4.2](https://github.com/graasp/graasp-ui/compare/v2.4.1...v2.4.2) (2023-04-27)
 
-
 ### Bug Fixes
 
-* ⚠️ Breaking change in the `AppItem` component props ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
-* app iframe loading forever ([#331](https://github.com/graasp/graasp-ui/issues/331)) ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
-* **ci:** storybook deploy to pages using artifacts ([#338](https://github.com/graasp/graasp-ui/issues/338)) ([c463fa0](https://github.com/graasp/graasp-ui/commit/c463fa0462a7e3302be83b84604f99b5b2d214ea))
-* **deps:** update packages (sdk, immutable) and yarn ([#334](https://github.com/graasp/graasp-ui/issues/334)) ([d1970fa](https://github.com/graasp/graasp-ui/commit/d1970faacb5efe65fc09989fa8f14d35d9f84724))
-* detect fullscreen changes ([#335](https://github.com/graasp/graasp-ui/issues/335)) ([190cbd2](https://github.com/graasp/graasp-ui/commit/190cbd222993524766e773c1e306e7e8599a3c87))
-* refactor AppItem to functional component ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
-* use a custom hook to setup the channel communication ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
-* use secondary color constant in theme ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
+- ⚠️ Breaking change in the `AppItem` component props ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
+- app iframe loading forever ([#331](https://github.com/graasp/graasp-ui/issues/331)) ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
+- **ci:** storybook deploy to pages using artifacts ([#338](https://github.com/graasp/graasp-ui/issues/338)) ([c463fa0](https://github.com/graasp/graasp-ui/commit/c463fa0462a7e3302be83b84604f99b5b2d214ea))
+- **deps:** update packages (sdk, immutable) and yarn ([#334](https://github.com/graasp/graasp-ui/issues/334)) ([d1970fa](https://github.com/graasp/graasp-ui/commit/d1970faacb5efe65fc09989fa8f14d35d9f84724))
+- detect fullscreen changes ([#335](https://github.com/graasp/graasp-ui/issues/335)) ([190cbd2](https://github.com/graasp/graasp-ui/commit/190cbd222993524766e773c1e306e7e8599a3c87))
+- refactor AppItem to functional component ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
+- use a custom hook to setup the channel communication ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
+- use secondary color constant in theme ([359d7ea](https://github.com/graasp/graasp-ui/commit/359d7ead4f89d0845af8477091ab85b2f30aa14f))
 
 ## [2.4.1](https://github.com/graasp/graasp-ui/compare/v2.4.0...v2.4.1) (2023-04-17)
 
-
 ### Bug Fixes
 
-* export public constants and refactor internal constants closer to their usage ([#330](https://github.com/graasp/graasp-ui/issues/330)) ([3e758b5](https://github.com/graasp/graasp-ui/commit/3e758b563792505b08af65052b44581f0e7a78b9))
+- export public constants and refactor internal constants closer to their usage ([#330](https://github.com/graasp/graasp-ui/issues/330)) ([3e758b5](https://github.com/graasp/graasp-ui/commit/3e758b563792505b08af65052b44581f0e7a78b9))
 
 ## [2.4.0](https://github.com/graasp/graasp-ui/compare/v2.3.1...v2.4.0) (2023-04-14)
 
-
 ### Features
 
-* Adds showCollapse to H5PItem, FileItem, AppItem, DocumentItem and LinkItem ([9b9ef52](https://github.com/graasp/graasp-ui/commit/9b9ef52442c00026a80c5bcfab74652af5321c89))
-
+- Adds showCollapse to H5PItem, FileItem, AppItem, DocumentItem and LinkItem ([9b9ef52](https://github.com/graasp/graasp-ui/commit/9b9ef52442c00026a80c5bcfab74652af5321c89))
 
 ### Bug Fixes
 
-* add DEFAULT_LINK_SHOW_BUTTON constant ([#328](https://github.com/graasp/graasp-ui/issues/328)) ([e0a3762](https://github.com/graasp/graasp-ui/commit/e0a3762ae7cec203a0ce170edf34cce8e68a2f66))
+- add DEFAULT_LINK_SHOW_BUTTON constant ([#328](https://github.com/graasp/graasp-ui/issues/328)) ([e0a3762](https://github.com/graasp/graasp-ui/commit/e0a3762ae7cec203a0ce170edf34cce8e68a2f66))
 
 ## [2.3.1](https://github.com/graasp/graasp-ui/compare/v2.3.0...v2.3.1) (2023-04-11)
 
-
 ### Bug Fixes
 
-* add collapsible and chat to itemstatus ([#313](https://github.com/graasp/graasp-ui/issues/313)) ([7014665](https://github.com/graasp/graasp-ui/commit/7014665d75d360843e5f4fdb4b24a4c5bebd2628))
-* remove title tag from LibraryIcon ([#321](https://github.com/graasp/graasp-ui/issues/321)) ([2ff6dbf](https://github.com/graasp/graasp-ui/commit/2ff6dbf1721c7536f183b88668285eed1605ad6f))
-* typo in release please workflow ([#318](https://github.com/graasp/graasp-ui/issues/318)) ([997f9cb](https://github.com/graasp/graasp-ui/commit/997f9cb32bdb35ea75457b8c88f18ee0dfe1bb22))
+- add collapsible and chat to itemstatus ([#313](https://github.com/graasp/graasp-ui/issues/313)) ([7014665](https://github.com/graasp/graasp-ui/commit/7014665d75d360843e5f4fdb4b24a4c5bebd2628))
+- remove title tag from LibraryIcon ([#321](https://github.com/graasp/graasp-ui/issues/321)) ([2ff6dbf](https://github.com/graasp/graasp-ui/commit/2ff6dbf1721c7536f183b88668285eed1605ad6f))
+- typo in release please workflow ([#318](https://github.com/graasp/graasp-ui/issues/318)) ([997f9cb](https://github.com/graasp/graasp-ui/commit/997f9cb32bdb35ea75457b8c88f18ee0dfe1bb22))
 
 ## [2.3.0](https://github.com/graasp/graasp-ui/compare/v2.2.1...v2.3.0) (2023-04-04)
 
-
 ### Features
 
-* add library icon setting cog option ([#312](https://github.com/graasp/graasp-ui/issues/312)) ([4b534bc](https://github.com/graasp/graasp-ui/commit/4b534bcfcb3c79e133007d39e6cdf0000f10d089))
+- add library icon setting cog option ([#312](https://github.com/graasp/graasp-ui/issues/312)) ([4b534bc](https://github.com/graasp/graasp-ui/commit/4b534bcfcb3c79e133007d39e6cdf0000f10d089))
 
 ## [2.2.1](https://github.com/graasp/graasp-ui/compare/v2.2.0...v2.2.1) (2023-03-25)
 
-
 ### Bug Fixes
 
-* add `cancelButtonId` prop to FileItem LinkItem an AppItem ([26d92e5](https://github.com/graasp/graasp-ui/commit/26d92e593693df61c898d3c377730bb9f9cc9eb7))
-* add `onCancelCaption` prop to FileItem ([#301](https://github.com/graasp/graasp-ui/issues/301)) ([f6fda11](https://github.com/graasp/graasp-ui/commit/f6fda1136472cc58b4e8f020d90af9af82d35b77))
-* add `onCancelCaption` prop to LinkItem and AppItem ([#306](https://github.com/graasp/graasp-ui/issues/306)) ([26d92e5](https://github.com/graasp/graasp-ui/commit/26d92e593693df61c898d3c377730bb9f9cc9eb7))
+- add `cancelButtonId` prop to FileItem LinkItem an AppItem ([26d92e5](https://github.com/graasp/graasp-ui/commit/26d92e593693df61c898d3c377730bb9f9cc9eb7))
+- add `onCancelCaption` prop to FileItem ([#301](https://github.com/graasp/graasp-ui/issues/301)) ([f6fda11](https://github.com/graasp/graasp-ui/commit/f6fda1136472cc58b4e8f020d90af9af82d35b77))
+- add `onCancelCaption` prop to LinkItem and AppItem ([#306](https://github.com/graasp/graasp-ui/issues/306)) ([26d92e5](https://github.com/graasp/graasp-ui/commit/26d92e593693df61c898d3c377730bb9f9cc9eb7))
 
 ## [2.2.0](https://github.com/graasp/graasp-ui/compare/v2.1.0...v2.2.0) (2023-03-16)
 
-
 ### Features
 
-* bump @graasp/sdk ([#297](https://github.com/graasp/graasp-ui/issues/297)) ([586661f](https://github.com/graasp/graasp-ui/commit/586661f3e497b40314405eab4e455974d2fa9bf6))
-
+- bump @graasp/sdk ([#297](https://github.com/graasp/graasp-ui/issues/297)) ([586661f](https://github.com/graasp/graasp-ui/commit/586661f3e497b40314405eab4e455974d2fa9bf6))
 
 ### Bug Fixes
 
-* etherpad icon use current color as default ([#295](https://github.com/graasp/graasp-ui/issues/295)) ([8132a39](https://github.com/graasp/graasp-ui/commit/8132a39c4cbd584a559ee14b52d314dd598dd8e2))
-* search bar can be compressed and is responsive ([#291](https://github.com/graasp/graasp-ui/issues/291)) ([72f22af](https://github.com/graasp/graasp-ui/commit/72f22af259e712deb1d3a0b76685ed2be69bbcff))
-* use a darker color for itemBadges ([#296](https://github.com/graasp/graasp-ui/issues/296)) ([e2f2f7a](https://github.com/graasp/graasp-ui/commit/e2f2f7a451c99b14362fa666e2883ab2de901768))
+- etherpad icon use current color as default ([#295](https://github.com/graasp/graasp-ui/issues/295)) ([8132a39](https://github.com/graasp/graasp-ui/commit/8132a39c4cbd584a559ee14b52d314dd598dd8e2))
+- search bar can be compressed and is responsive ([#291](https://github.com/graasp/graasp-ui/issues/291)) ([72f22af](https://github.com/graasp/graasp-ui/commit/72f22af259e712deb1d3a0b76685ed2be69bbcff))
+- use a darker color for itemBadges ([#296](https://github.com/graasp/graasp-ui/issues/296)) ([e2f2f7a](https://github.com/graasp/graasp-ui/commit/e2f2f7a451c99b14362fa666e2883ab2de901768))
 
 ## [2.1.0](https://github.com/graasp/graasp-ui/compare/v2.0.1...v2.1.0) (2023-03-15)
 
-
 ### Features
 
-* add etherpad logo ([#277](https://github.com/graasp/graasp-ui/issues/277)) ([4ddc7e9](https://github.com/graasp/graasp-ui/commit/4ddc7e989c3cda085b6c174887e0d8b03e7b412e))
-* add header platform colors ([#279](https://github.com/graasp/graasp-ui/issues/279)) ([1eac4be](https://github.com/graasp/graasp-ui/commit/1eac4beb17164a3383e3b4f2cc674edad8c87eec))
-* **ui:** add `ItemBadges` component ([#283](https://github.com/graasp/graasp-ui/issues/283)) ([23e3ffb](https://github.com/graasp/graasp-ui/commit/23e3ffb3a011e6094e3ecddc77cda8326f5703fd))
-
+- add etherpad logo ([#277](https://github.com/graasp/graasp-ui/issues/277)) ([4ddc7e9](https://github.com/graasp/graasp-ui/commit/4ddc7e989c3cda085b6c174887e0d8b03e7b412e))
+- add header platform colors ([#279](https://github.com/graasp/graasp-ui/issues/279)) ([1eac4be](https://github.com/graasp/graasp-ui/commit/1eac4beb17164a3383e3b4f2cc674edad8c87eec))
+- **ui:** add `ItemBadges` component ([#283](https://github.com/graasp/graasp-ui/issues/283)) ([23e3ffb](https://github.com/graasp/graasp-ui/commit/23e3ffb3a011e6094e3ecddc77cda8326f5703fd))
 
 ### Bug Fixes
 
-* fix operator priority on `FavoriteButton` tooltip ([#287](https://github.com/graasp/graasp-ui/issues/287)) ([b42b38b](https://github.com/graasp/graasp-ui/commit/b42b38be72cd3087e606250045b29d669d956a03))
-* **table:** reduce spacing of drag icon column and padding around elements ([23e3ffb](https://github.com/graasp/graasp-ui/commit/23e3ffb3a011e6094e3ecddc77cda8326f5703fd))
+- fix operator priority on `FavoriteButton` tooltip ([#287](https://github.com/graasp/graasp-ui/issues/287)) ([b42b38b](https://github.com/graasp/graasp-ui/commit/b42b38be72cd3087e606250045b29d669d956a03))
+- **table:** reduce spacing of drag icon column and padding around elements ([23e3ffb](https://github.com/graasp/graasp-ui/commit/23e3ffb3a011e6094e3ecddc77cda8326f5703fd))
 
 ## [2.0.1](https://github.com/graasp/graasp-ui/compare/v2.0.0...v2.0.1) (2023-03-09)
 
-
 ### Bug Fixes
 
-* use MimeTypes and ThumbnailSize from sdk ([#274](https://github.com/graasp/graasp-ui/issues/274)) ([3dd2f08](https://github.com/graasp/graasp-ui/commit/3dd2f082b5d7e6f057d2aaa1fa96ac9b14c38458))
+- use MimeTypes and ThumbnailSize from sdk ([#274](https://github.com/graasp/graasp-ui/issues/274)) ([3dd2f08](https://github.com/graasp/graasp-ui/commit/3dd2f082b5d7e6f057d2aaa1fa96ac9b14c38458))
 
 ## [2.0.0](https://github.com/graasp/graasp-ui/compare/v1.0.0...v2.0.0) (2023-03-06)
 
-
 ### ⚠ BREAKING CHANGES
 
-* refactor exported types, remove old navigation ([#271](https://github.com/graasp/graasp-ui/issues/271))
+- refactor exported types, remove old navigation ([#271](https://github.com/graasp/graasp-ui/issues/271))
 
 ### Features
 
-* refactor exported types, remove old navigation ([#271](https://github.com/graasp/graasp-ui/issues/271)) ([0cc9f94](https://github.com/graasp/graasp-ui/commit/0cc9f9480d30ff65e0bb14ca5ce899fac39619e7))
+- refactor exported types, remove old navigation ([#271](https://github.com/graasp/graasp-ui/issues/271)) ([0cc9f94](https://github.com/graasp/graasp-ui/commit/0cc9f9480d30ff65e0bb14ca5ce899fac39619e7))
 
 ## [1.0.0](https://github.com/graasp/graasp-ui/compare/v0.13.0...v1.0.0) (2023-03-03)
 
-
 ### ⚠ BREAKING CHANGES
 
-* remove `BUTTON_TYPES` constant and use `ButtonTypeEnum` ([#260](https://github.com/graasp/graasp-ui/issues/260))
+- remove `BUTTON_TYPES` constant and use `ButtonTypeEnum` ([#260](https://github.com/graasp/graasp-ui/issues/260))
 
 ### Features
 
-* implement document style flavors ([#241](https://github.com/graasp/graasp-ui/issues/241)) ([8dbecb7](https://github.com/graasp/graasp-ui/commit/8dbecb74082849b06c5dcb342dd9300c16adbc12))
-
+- implement document style flavors ([#241](https://github.com/graasp/graasp-ui/issues/241)) ([8dbecb7](https://github.com/graasp/graasp-ui/commit/8dbecb74082849b06c5dcb342dd9300c16adbc12))
 
 ### Bug Fixes
 
-* add key to list element in platform switch ([#266](https://github.com/graasp/graasp-ui/issues/266)) ([bc7d5f2](https://github.com/graasp/graasp-ui/commit/bc7d5f2081183f2f2853be2b4f3279578459d357))
-* change default favoritebutton icon size to medium and add a menuItem story ([6302d46](https://github.com/graasp/graasp-ui/commit/6302d46ec6bb12de7c9862b12c07e5b10ff0c78e))
-* improve card component and add stories ([#259](https://github.com/graasp/graasp-ui/issues/259)) ([fc3e120](https://github.com/graasp/graasp-ui/commit/fc3e12054cfa19d779abbfd06601814f01059def))
-* improve optional types on `ItemLoginAuthorization` ([#268](https://github.com/graasp/graasp-ui/issues/268)) ([d8e20a3](https://github.com/graasp/graasp-ui/commit/d8e20a307c6b391d632240f99fea60c1672c8110))
-* remove `BUTTON_TYPES` constant and use `ButtonTypeEnum` ([#260](https://github.com/graasp/graasp-ui/issues/260)) ([6302d46](https://github.com/graasp/graasp-ui/commit/6302d46ec6bb12de7c9862b12c07e5b10ff0c78e))
-* set default skeleton variant to circular for Avatar ([#264](https://github.com/graasp/graasp-ui/issues/264)) ([30fddbc](https://github.com/graasp/graasp-ui/commit/30fddbc091df3a26c20647d5e37fe9f263f050a2))
-* **types:** `withCollapse` uses `ItemRecord` ([d8e20a3](https://github.com/graasp/graasp-ui/commit/d8e20a307c6b391d632240f99fea60c1672c8110))
-* **types:** improve types of itemType prop in SkeletonItem ([30fddbc](https://github.com/graasp/graasp-ui/commit/30fddbc091df3a26c20647d5e37fe9f263f050a2))
-* **types:** make `onSave` optional in `DocumentItem` for readOnly mode ([d8e20a3](https://github.com/graasp/graasp-ui/commit/d8e20a307c6b391d632240f99fea60c1672c8110))
-
+- add key to list element in platform switch ([#266](https://github.com/graasp/graasp-ui/issues/266)) ([bc7d5f2](https://github.com/graasp/graasp-ui/commit/bc7d5f2081183f2f2853be2b4f3279578459d357))
+- change default favoritebutton icon size to medium and add a menuItem story ([6302d46](https://github.com/graasp/graasp-ui/commit/6302d46ec6bb12de7c9862b12c07e5b10ff0c78e))
+- improve card component and add stories ([#259](https://github.com/graasp/graasp-ui/issues/259)) ([fc3e120](https://github.com/graasp/graasp-ui/commit/fc3e12054cfa19d779abbfd06601814f01059def))
+- improve optional types on `ItemLoginAuthorization` ([#268](https://github.com/graasp/graasp-ui/issues/268)) ([d8e20a3](https://github.com/graasp/graasp-ui/commit/d8e20a307c6b391d632240f99fea60c1672c8110))
+- remove `BUTTON_TYPES` constant and use `ButtonTypeEnum` ([#260](https://github.com/graasp/graasp-ui/issues/260)) ([6302d46](https://github.com/graasp/graasp-ui/commit/6302d46ec6bb12de7c9862b12c07e5b10ff0c78e))
+- set default skeleton variant to circular for Avatar ([#264](https://github.com/graasp/graasp-ui/issues/264)) ([30fddbc](https://github.com/graasp/graasp-ui/commit/30fddbc091df3a26c20647d5e37fe9f263f050a2))
+- **types:** `withCollapse` uses `ItemRecord` ([d8e20a3](https://github.com/graasp/graasp-ui/commit/d8e20a307c6b391d632240f99fea60c1672c8110))
+- **types:** improve types of itemType prop in SkeletonItem ([30fddbc](https://github.com/graasp/graasp-ui/commit/30fddbc091df3a26c20647d5e37fe9f263f050a2))
+- **types:** make `onSave` optional in `DocumentItem` for readOnly mode ([d8e20a3](https://github.com/graasp/graasp-ui/commit/d8e20a307c6b391d632240f99fea60c1672c8110))
 
 ### Documentation
 
-* update license in readme ([#270](https://github.com/graasp/graasp-ui/issues/270)) ([26f5478](https://github.com/graasp/graasp-ui/commit/26f547808b46f05382bc8fba76bc7c7174537fe3))
+- update license in readme ([#270](https://github.com/graasp/graasp-ui/issues/270)) ([26f5478](https://github.com/graasp/graasp-ui/commit/26f547808b46f05382bc8fba76bc7c7174537fe3))
 
 ## [0.13.0](https://github.com/graasp/graasp-ui/compare/v0.12.0...v0.13.0) (2023-02-24)
 
-
 ### Features
 
-* support `wav` and `svg` formats ([#256](https://github.com/graasp/graasp-ui/issues/256)) ([b7ece2d](https://github.com/graasp/graasp-ui/commit/b7ece2dd1f7bb50b8937051299d1c391c52ca172))
+- support `wav` and `svg` formats ([#256](https://github.com/graasp/graasp-ui/issues/256)) ([b7ece2d](https://github.com/graasp/graasp-ui/commit/b7ece2dd1f7bb50b8937051299d1c391c52ca172))
 
 ## [0.12.0](https://github.com/graasp/graasp-ui/compare/v0.11.2...v0.12.0) (2023-02-22)
 
-
 ### Features
 
-* return lang from member and item in app item ([#238](https://github.com/graasp/graasp-ui/issues/238)) ([5608bf0](https://github.com/graasp/graasp-ui/commit/5608bf03a4eaed12e647c99923d64820f04f1ca4))
+- return lang from member and item in app item ([#238](https://github.com/graasp/graasp-ui/issues/238)) ([5608bf0](https://github.com/graasp/graasp-ui/commit/5608bf03a4eaed12e647c99923d64820f04f1ca4))
 
 ## [0.11.2](https://github.com/graasp/graasp-ui/compare/v0.11.1...v0.11.2) (2023-02-21)
 
-
 ### Bug Fixes
 
-* add `span`s below tooltip to ensure icon stay round ([8877111](https://github.com/graasp/graasp-ui/commit/88771117906c8fdc3c228ff8a464b14e94fbe148))
-* do not show placeholder text when in readOnly mode ([8877111](https://github.com/graasp/graasp-ui/commit/88771117906c8fdc3c228ff8a464b14e94fbe148))
-* **ui:** change `ShareButton` icon ([#245](https://github.com/graasp/graasp-ui/issues/245)) ([8877111](https://github.com/graasp/graasp-ui/commit/88771117906c8fdc3c228ff8a464b14e94fbe148))
+- add `span`s below tooltip to ensure icon stay round ([8877111](https://github.com/graasp/graasp-ui/commit/88771117906c8fdc3c228ff8a464b14e94fbe148))
+- do not show placeholder text when in readOnly mode ([8877111](https://github.com/graasp/graasp-ui/commit/88771117906c8fdc3c228ff8a464b14e94fbe148))
+- **ui:** change `ShareButton` icon ([#245](https://github.com/graasp/graasp-ui/issues/245)) ([8877111](https://github.com/graasp/graasp-ui/commit/88771117906c8fdc3c228ff8a464b14e94fbe148))
 
 ## [0.11.1](https://github.com/graasp/graasp-ui/compare/v0.11.0...v0.11.1) (2023-02-16)
 
-
 ### Bug Fixes
 
-* add URL transforms for all platforms ([#234](https://github.com/graasp/graasp-ui/issues/234)) ([927f303](https://github.com/graasp/graasp-ui/commit/927f303b2085a05aebb58a73d5d8094e5b93707f))
+- add URL transforms for all platforms ([#234](https://github.com/graasp/graasp-ui/issues/234)) ([927f303](https://github.com/graasp/graasp-ui/commit/927f303b2085a05aebb58a73d5d8094e5b93707f))
 
 ## [0.11.0](https://github.com/graasp/graasp-ui/compare/v0.10.5...v0.11.0) (2023-02-16)
 
-
 ### Features
 
-* move types to sdk and use types from @graasp/sdk/frontend ([#228](https://github.com/graasp/graasp-ui/issues/228)) ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f)), closes [#235](https://github.com/graasp/graasp-ui/issues/235) [#202](https://github.com/graasp/graasp-ui/issues/202)
-
+- move types to sdk and use types from @graasp/sdk/frontend ([#228](https://github.com/graasp/graasp-ui/issues/228)) ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f)), closes [#235](https://github.com/graasp/graasp-ui/issues/235) [#202](https://github.com/graasp/graasp-ui/issues/202)
 
 ### Bug Fixes
 
-* **types:** add type annotation for StyledIframe ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
-* **types:** update ItemIcon type prop to accept string litteral from ItemType enum ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
-* update ItemIcon `extra` prop ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
-* update LinkItem props ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
-* update type of useMember hook ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
-* useItem type in `ItemLoginAuthorization` ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
-* various component props ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
+- **types:** add type annotation for StyledIframe ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
+- **types:** update ItemIcon type prop to accept string litteral from ItemType enum ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
+- update ItemIcon `extra` prop ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
+- update LinkItem props ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
+- update type of useMember hook ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
+- useItem type in `ItemLoginAuthorization` ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
+- various component props ([1f31b54](https://github.com/graasp/graasp-ui/commit/1f31b5431d5f1f142a22cb9f2f91c6959618aa6f))
 
 ## [0.10.5](https://github.com/graasp/graasp-ui/compare/v0.10.4...v0.10.5) (2023-02-14)
 
-
 ### Bug Fixes
 
-* allow keyboard nav in menu and table ([#227](https://github.com/graasp/graasp-ui/issues/227)) ([d550913](https://github.com/graasp/graasp-ui/commit/d550913aaeb9645e687fc9f4311ccc1ac0e111c3))
+- allow keyboard nav in menu and table ([#227](https://github.com/graasp/graasp-ui/issues/227)) ([d550913](https://github.com/graasp/graasp-ui/commit/d550913aaeb9645e687fc9f4311ccc1ac0e111c3))
 
 ## [0.10.4](https://github.com/graasp/graasp-ui/compare/v0.10.3...v0.10.4) (2023-02-13)
 
-
 ### Bug Fixes
 
-* revert [#224](https://github.com/graasp/graasp-ui/issues/224) ([bea6b07](https://github.com/graasp/graasp-ui/commit/bea6b07cdd424f852e3a53683d72c31cdad3c8b3))
+- revert [#224](https://github.com/graasp/graasp-ui/issues/224) ([bea6b07](https://github.com/graasp/graasp-ui/commit/bea6b07cdd424f852e3a53683d72c31cdad3c8b3))
 
 ## [0.10.3](https://github.com/graasp/graasp-ui/compare/v0.10.2...v0.10.3) (2023-02-13)
 
-
 ### Bug Fixes
 
-* clear hover state when platform opens in new tab ([#224](https://github.com/graasp/graasp-ui/issues/224)) ([0881b2a](https://github.com/graasp/graasp-ui/commit/0881b2a3f9d52cc6f75a4ae83fa74fc399dcaadc))
+- clear hover state when platform opens in new tab ([#224](https://github.com/graasp/graasp-ui/issues/224)) ([0881b2a](https://github.com/graasp/graasp-ui/commit/0881b2a3f9d52cc6f75a4ae83fa74fc399dcaadc))
 
 ## [0.10.2](https://github.com/graasp/graasp-ui/compare/v0.10.1...v0.10.2) (2023-02-07)
 
-
 ### Bug Fixes
 
-* use MouseEvent from react in PlatformSwitch ([434e862](https://github.com/graasp/graasp-ui/commit/434e862754211e603b5058ed8031754cf4a3b802))
+- use MouseEvent from react in PlatformSwitch ([434e862](https://github.com/graasp/graasp-ui/commit/434e862754211e603b5058ed8031754cf4a3b802))
 
 ## [0.10.1](https://github.com/graasp/graasp-ui/compare/v0.10.0...v0.10.1) (2023-02-07)
 
-
 ### Bug Fixes
 
-* add platform switch ids, use nav controls, handle middle click  ([#221](https://github.com/graasp/graasp-ui/issues/221)) ([6d45212](https://github.com/graasp/graasp-ui/commit/6d4521228294a9abaf108a98eafc394efd1b1b3c))
+- add platform switch ids, use nav controls, handle middle click ([#221](https://github.com/graasp/graasp-ui/issues/221)) ([6d45212](https://github.com/graasp/graasp-ui/commit/6d4521228294a9abaf108a98eafc394efd1b1b3c))
 
 ## [0.10.0](https://github.com/graasp/graasp-ui/compare/v0.9.0...v0.10.0) (2023-02-07)
 
-
 ### Features
 
-* add PlatformSwitch component ([#216](https://github.com/graasp/graasp-ui/issues/216)) ([1621c43](https://github.com/graasp/graasp-ui/commit/1621c43ff0f66eca4a4108ff9f54a1d74ffe40ae))
+- add PlatformSwitch component ([#216](https://github.com/graasp/graasp-ui/issues/216)) ([1621c43](https://github.com/graasp/graasp-ui/commit/1621c43ff0f66eca4a4108ff9f54a1d74ffe40ae))
 
 ## [0.9.0](https://github.com/graasp/graasp-ui/compare/v0.8.0...v0.9.0) (2023-02-06)
 
-
 ### Features
 
-* add fullHeight prop to MainMenu ([#218](https://github.com/graasp/graasp-ui/issues/218)) ([f343e66](https://github.com/graasp/graasp-ui/commit/f343e667849850f34aa1daff6f0b9d2d2e29d811))
+- add fullHeight prop to MainMenu ([#218](https://github.com/graasp/graasp-ui/issues/218)) ([f343e66](https://github.com/graasp/graasp-ui/commit/f343e667849850f34aa1daff6f0b9d2d2e29d811))
 
 ## [0.8.0](https://github.com/graasp/graasp-ui/compare/v0.7.1...v0.8.0) (2023-01-26)
 
-
 ### Features
 
-* add handleDrawerOpen and handleDrawerClose to Main ([7e3cd9b](https://github.com/graasp/graasp-ui/commit/7e3cd9bf4ad2629f5e68d1e4243c9f7f62f945c8))
+- add handleDrawerOpen and handleDrawerClose to Main ([7e3cd9b](https://github.com/graasp/graasp-ui/commit/7e3cd9bf4ad2629f5e68d1e4243c9f7f62f945c8))
 
 ## [0.7.1](https://github.com/graasp/graasp-ui/compare/v0.7.0...v0.7.1) (2023-01-19)
 
-
 ### Bug Fixes
 
-* h5p revert to default iframe ([#208](https://github.com/graasp/graasp-ui/issues/208)) ([aba3d1e](https://github.com/graasp/graasp-ui/commit/aba3d1e6468d55e2b2b4d951fe8219759fb68cf7))
+- h5p revert to default iframe ([#208](https://github.com/graasp/graasp-ui/issues/208)) ([aba3d1e](https://github.com/graasp/graasp-ui/commit/aba3d1e6468d55e2b2b4d951fe8219759fb68cf7))
 
 ## [0.7.0](https://github.com/graasp/graasp-ui/compare/v0.6.0...v0.7.0) (2023-01-06)
 
-
 ### Features
 
-* add etherpad UI components ([#206](https://github.com/graasp/graasp-ui/issues/206)) ([5c6bf3f](https://github.com/graasp/graasp-ui/commit/5c6bf3f2ec69a7bf4124931360fbda80f34e0ccc))
+- add etherpad UI components ([#206](https://github.com/graasp/graasp-ui/issues/206)) ([5c6bf3f](https://github.com/graasp/graasp-ui/commit/5c6bf3f2ec69a7bf4124931360fbda80f34e0ccc))
 
 ## [0.6.0](https://github.com/graasp/graasp-ui/compare/v0.5.0...v0.6.0) (2022-12-15)
 
-
 ### Features
 
-* move types ([c5333a3](https://github.com/graasp/graasp-ui/commit/c5333a383ea4d7c1e30a20ec2ea956b341cdfb60))
-
+- move types ([c5333a3](https://github.com/graasp/graasp-ui/commit/c5333a383ea4d7c1e30a20ec2ea956b341cdfb60))
 
 ### Bug Fixes
 
-* patch issues ([a3a2007](https://github.com/graasp/graasp-ui/commit/a3a20076b97cfa13f0e221cf5f3886c0368bc8c6))
-* types usages ([2955223](https://github.com/graasp/graasp-ui/commit/2955223918b3ece2b57c964a3b7dfe3795c17c71))
+- patch issues ([a3a2007](https://github.com/graasp/graasp-ui/commit/a3a20076b97cfa13f0e221cf5f3886c0368bc8c6))
+- types usages ([2955223](https://github.com/graasp/graasp-ui/commit/2955223918b3ece2b57c964a3b7dfe3795c17c71))
 
 ## [0.5.0](https://github.com/graasp/graasp-ui/compare/v0.4.2...v0.5.0) (2022-12-13)
 
-
 ### Features
 
-* add fullscreen custom hook ([402f35f](https://github.com/graasp/graasp-ui/commit/402f35f2772e4e5e0814b10d9bfd3ab1beca6cca))
-
+- add fullscreen custom hook ([402f35f](https://github.com/graasp/graasp-ui/commit/402f35f2772e4e5e0814b10d9bfd3ab1beca6cca))
 
 ### Bug Fixes
 
-* update npm publish deployement ([451ec2a](https://github.com/graasp/graasp-ui/commit/451ec2a70195019f9bb3d8585396f3a64ae843ff))
+- update npm publish deployement ([451ec2a](https://github.com/graasp/graasp-ui/commit/451ec2a70195019f9bb3d8585396f3a64ae843ff))
 
 ## [0.4.2](https://github.com/graasp/graasp-ui/compare/v0.4.1...v0.4.2) (2022-12-01)
 
-
 ### Bug Fixes
 
-* allow fullscreen on app iframes ([29fbdd3](https://github.com/graasp/graasp-ui/commit/29fbdd34300e7439bbd17efac5ce5d6f601eff74))
+- allow fullscreen on app iframes ([29fbdd3](https://github.com/graasp/graasp-ui/commit/29fbdd34300e7439bbd17efac5ce5d6f601eff74))
 
 ## [0.4.1](https://github.com/graasp/graasp-ui/compare/v0.4.0...v0.4.1) (2022-11-21)
 
-
 ### Bug Fixes
 
-* add build step and quill-emoji declarations ([#185](https://github.com/graasp/graasp-ui/issues/185)) ([71703e7](https://github.com/graasp/graasp-ui/commit/71703e72a06a1ca826292be1eb09e430b36f679a))
-* add missing break ([c0fe093](https://github.com/graasp/graasp-ui/commit/c0fe0930c5470b8677b17aa879b8b31d8b48bf20))
+- add build step and quill-emoji declarations ([#185](https://github.com/graasp/graasp-ui/issues/185)) ([71703e7](https://github.com/graasp/graasp-ui/commit/71703e72a06a1ca826292be1eb09e430b36f679a))
+- add missing break ([c0fe093](https://github.com/graasp/graasp-ui/commit/c0fe0930c5470b8677b17aa879b8b31d8b48bf20))
 
 ## [0.4.0](https://github.com/graasp/graasp-ui/compare/v0.3.1...v0.4.0) (2022-11-18)
 
-
 ### Features
 
-* add auto-resize message listener ([#183](https://github.com/graasp/graasp-ui/issues/183)) ([becfd7b](https://github.com/graasp/graasp-ui/commit/becfd7b48c9a971367991290cff5c972d5492ed3))
+- add auto-resize message listener ([#183](https://github.com/graasp/graasp-ui/issues/183)) ([becfd7b](https://github.com/graasp/graasp-ui/commit/becfd7b48c9a971367991290cff5c972d5492ed3))
 
 ## [0.3.1](https://github.com/graasp/graasp-ui/compare/v0.3.0...v0.3.1) (2022-11-01)
 
-
 ### Bug Fixes
 
-* add master branch to trigger workflows ([6b275c0](https://github.com/graasp/graasp-ui/commit/6b275c0c706487250239fc6bc787d9b2d529bd58))
-
+- add master branch to trigger workflows ([6b275c0](https://github.com/graasp/graasp-ui/commit/6b275c0c706487250239fc6bc787d9b2d529bd58))
 
 ### Documentation
 
-* **readme:** udpate badges and add storybook link in readme ([#178](https://github.com/graasp/graasp-ui/issues/178)) ([689ff62](https://github.com/graasp/graasp-ui/commit/689ff626edccf3bce5e05202ab9a1713ee903757))
+- **readme:** udpate badges and add storybook link in readme ([#178](https://github.com/graasp/graasp-ui/issues/178)) ([689ff62](https://github.com/graasp/graasp-ui/commit/689ff626edccf3bce5e05202ab9a1713ee903757))
 
 ## [0.3.0](https://github.com/graasp/graasp-ui/compare/v0.2.1...v0.3.0) (2022-10-24)
 
 ### [0.2.1](https://github.com/graasp/graasp-ui/compare/v0.2.0...v0.2.1) (2022-10-24)
 
-
 ### Features
 
-* add captions to items ([8fc1d34](https://github.com/graasp/graasp-ui/commit/8fc1d3435ba6401144f31f8d7cd59c39a8ad980f))
-* add Card component ([6c98ae7](https://github.com/graasp/graasp-ui/commit/6c98ae7a85cb00c80a5c51eaf3a706d0ed2f8a9e))
-* add CC License Icons ([807b6a6](https://github.com/graasp/graasp-ui/commit/807b6a6afce9e63b3d6f1a6d7c9aa6783855dbcd))
-* add Collapse component ([3fe20b5](https://github.com/graasp/graasp-ui/commit/3fe20b5dcd5cda2b40aa3acbe40b4da18db2785f))
-* add color prop ([b0ddf3d](https://github.com/graasp/graasp-ui/commit/b0ddf3d6eaa36d7a42139a8f038d6a4ef7f41c5c))
-* add cookie to save height ([89763a5](https://github.com/graasp/graasp-ui/commit/89763a5ec073a21e819823a4f413fc7f906b156f))
-* add cookies banner ([8a5bd57](https://github.com/graasp/graasp-ui/commit/8a5bd57da57c949308f33c8ee48c629a5db6bcae))
-* add data in appitem context ([2f20f22](https://github.com/graasp/graasp-ui/commit/2f20f22dc910cd09fed3786a593d0a2945fd973c))
-* add dataCy prop to Button ([c957e05](https://github.com/graasp/graasp-ui/commit/c957e05969f8ffcb09dce888c1d4c1d7317aad70))
-* add download button ([8335776](https://github.com/graasp/graasp-ui/commit/833577607913ed642c57bba03f0a01ec979f81b3))
-* add Dynamic Tree View ([3850467](https://github.com/graasp/graasp-ui/commit/385046730d899b941e7badfe718972c742179e6c))
-* add favorite button component ([35787a5](https://github.com/graasp/graasp-ui/commit/35787a5d08481ba3956f7a3ff53c6be25b17af2a))
-* add FlagItemButton component ([c5fff19](https://github.com/graasp/graasp-ui/commit/c5fff19d948e31ae6c94361fe484a476fba855db))
-* add graasp button ([a3a039a](https://github.com/graasp/graasp-ui/commit/a3a039a2fc5b52f4e8fe77f246daa294dbe16029))
-* add graasp initial loader and use skeleton ([22c15ae](https://github.com/graasp/graasp-ui/commit/22c15ae921fbb821e2cc8339cac9f573bb9ccad3))
-* add Graasp Logo ([6518ec9](https://github.com/graasp/graasp-ui/commit/6518ec9cee1a170269bce98a9121d1b253c38f75))
-* add H5P iframe integration ([#140](https://github.com/graasp/graasp-ui/issues/140)) ([8e38ca1](https://github.com/graasp/graasp-ui/commit/8e38ca1792bc922cfaff872551620ef8a20db7c9))
-* add header user information ([7ed71d0](https://github.com/graasp/graasp-ui/commit/7ed71d0cf88df9f9f7dca42f78a937d70c1c3284))
-* add Header User Information ([6c824ee](https://github.com/graasp/graasp-ui/commit/6c824eed22ec395ea962bb2c6e042c2fc54230e9))
-* add item components ([c9df0b0](https://github.com/graasp/graasp-ui/commit/c9df0b0364071ab74d9be1f1c72ed6736c893a9b))
-* add item flag menu to UI component ([da5d377](https://github.com/graasp/graasp-ui/commit/da5d377129a598e3f0c88a595be92f16730e0c6c))
-* add item icon ([2cac46d](https://github.com/graasp/graasp-ui/commit/2cac46db7e1c128c2cdf3e17aa12171b03158970))
-* add item id in post message keys ([0882f87](https://github.com/graasp/graasp-ui/commit/0882f8739e95f9035e2dd2b7dfe6fa71d545bea6))
-* add Item Login Authorization and Screen ([f9ab12c](https://github.com/graasp/graasp-ui/commit/f9ab12c5f87d8912fb27f6e2bdc86e2bb35ae956))
-* add ItemSkeleton component ([9277779](https://github.com/graasp/graasp-ui/commit/92777792a87f4ddeadc6f8191f5a403aa961713e))
-* add left and right content to header ([53f8eb0](https://github.com/graasp/graasp-ui/commit/53f8eb066ac5cca676f34fa6339a6a11675f4c4d))
-* add like button ([d635ae4](https://github.com/graasp/graasp-ui/commit/d635ae427d80aea5498816e4868582bf223d1aaf))
-* add link button for iframe ([d8c4568](https://github.com/graasp/graasp-ui/commit/d8c45686417108e343fad08cd489b0e90901284d))
-* add link to storybook, add showIframe and showButton booleans ([#162](https://github.com/graasp/graasp-ui/issues/162)) ([13ae642](https://github.com/graasp/graasp-ui/commit/13ae642e8cfbb9e23404a540b168331a32fe6c8a))
-* add Main, MainMenu, DrawerHeader and Sidebar components, tests ([d47b1db](https://github.com/graasp/graasp-ui/commit/d47b1dbd16d575f8583d651cd6382ab7444e972c))
-* add message to update app settings ([644fb1d](https://github.com/graasp/graasp-ui/commit/644fb1d22e77244b50fa64da1ffcdab3cf429694))
-* add more headings and fonts for text editor ([3912f14](https://github.com/graasp/graasp-ui/commit/3912f147f6893e212b2d69d9f37ef22bb09ae7b6))
-* add settings update ([7a18bdb](https://github.com/graasp/graasp-ui/commit/7a18bdb2d5d344071a7c8c3683f9c5cf22221253))
-* add size in thumbnail and avatar ([ecac066](https://github.com/graasp/graasp-ui/commit/ecac066cfdc4520337751a975cf4c215b80778d0))
-* add support for audio files ([5990152](https://github.com/graasp/graasp-ui/commit/5990152ea10ec9a38501bd486cfe0d836750459f))
-* add thumbnail and avatar components ([9241091](https://github.com/graasp/graasp-ui/commit/9241091895e195401419b144cb54e54ce11cc876))
-* add withResize variable height ([aa79f19](https://github.com/graasp/graasp-ui/commit/aa79f19c23e1ce855462936dc966f4577816b11d))
-* change icon to star ([e71bb5e](https://github.com/graasp/graasp-ui/commit/e71bb5ef917f34a288eaa3c0122c922a583a48a2))
-* extension feature to links and apps ([3f445de](https://github.com/graasp/graasp-ui/commit/3f445debf7443eb30e6f272f9c62e68d9690b7c2))
-* set up first components Loader and Header (tbd) ([5ae9105](https://github.com/graasp/graasp-ui/commit/5ae910511c3126d33ae743aa7b73bb91f0ceb12f))
-* update graasp logo, add navigation component ([edf2cab](https://github.com/graasp/graasp-ui/commit/edf2cab70c2958d4a730d491cc696138c1bf2b69))
-
+- add captions to items ([8fc1d34](https://github.com/graasp/graasp-ui/commit/8fc1d3435ba6401144f31f8d7cd59c39a8ad980f))
+- add Card component ([6c98ae7](https://github.com/graasp/graasp-ui/commit/6c98ae7a85cb00c80a5c51eaf3a706d0ed2f8a9e))
+- add CC License Icons ([807b6a6](https://github.com/graasp/graasp-ui/commit/807b6a6afce9e63b3d6f1a6d7c9aa6783855dbcd))
+- add Collapse component ([3fe20b5](https://github.com/graasp/graasp-ui/commit/3fe20b5dcd5cda2b40aa3acbe40b4da18db2785f))
+- add color prop ([b0ddf3d](https://github.com/graasp/graasp-ui/commit/b0ddf3d6eaa36d7a42139a8f038d6a4ef7f41c5c))
+- add cookie to save height ([89763a5](https://github.com/graasp/graasp-ui/commit/89763a5ec073a21e819823a4f413fc7f906b156f))
+- add cookies banner ([8a5bd57](https://github.com/graasp/graasp-ui/commit/8a5bd57da57c949308f33c8ee48c629a5db6bcae))
+- add data in appitem context ([2f20f22](https://github.com/graasp/graasp-ui/commit/2f20f22dc910cd09fed3786a593d0a2945fd973c))
+- add dataCy prop to Button ([c957e05](https://github.com/graasp/graasp-ui/commit/c957e05969f8ffcb09dce888c1d4c1d7317aad70))
+- add download button ([8335776](https://github.com/graasp/graasp-ui/commit/833577607913ed642c57bba03f0a01ec979f81b3))
+- add Dynamic Tree View ([3850467](https://github.com/graasp/graasp-ui/commit/385046730d899b941e7badfe718972c742179e6c))
+- add favorite button component ([35787a5](https://github.com/graasp/graasp-ui/commit/35787a5d08481ba3956f7a3ff53c6be25b17af2a))
+- add FlagItemButton component ([c5fff19](https://github.com/graasp/graasp-ui/commit/c5fff19d948e31ae6c94361fe484a476fba855db))
+- add graasp button ([a3a039a](https://github.com/graasp/graasp-ui/commit/a3a039a2fc5b52f4e8fe77f246daa294dbe16029))
+- add graasp initial loader and use skeleton ([22c15ae](https://github.com/graasp/graasp-ui/commit/22c15ae921fbb821e2cc8339cac9f573bb9ccad3))
+- add Graasp Logo ([6518ec9](https://github.com/graasp/graasp-ui/commit/6518ec9cee1a170269bce98a9121d1b253c38f75))
+- add H5P iframe integration ([#140](https://github.com/graasp/graasp-ui/issues/140)) ([8e38ca1](https://github.com/graasp/graasp-ui/commit/8e38ca1792bc922cfaff872551620ef8a20db7c9))
+- add header user information ([7ed71d0](https://github.com/graasp/graasp-ui/commit/7ed71d0cf88df9f9f7dca42f78a937d70c1c3284))
+- add Header User Information ([6c824ee](https://github.com/graasp/graasp-ui/commit/6c824eed22ec395ea962bb2c6e042c2fc54230e9))
+- add item components ([c9df0b0](https://github.com/graasp/graasp-ui/commit/c9df0b0364071ab74d9be1f1c72ed6736c893a9b))
+- add item flag menu to UI component ([da5d377](https://github.com/graasp/graasp-ui/commit/da5d377129a598e3f0c88a595be92f16730e0c6c))
+- add item icon ([2cac46d](https://github.com/graasp/graasp-ui/commit/2cac46db7e1c128c2cdf3e17aa12171b03158970))
+- add item id in post message keys ([0882f87](https://github.com/graasp/graasp-ui/commit/0882f8739e95f9035e2dd2b7dfe6fa71d545bea6))
+- add Item Login Authorization and Screen ([f9ab12c](https://github.com/graasp/graasp-ui/commit/f9ab12c5f87d8912fb27f6e2bdc86e2bb35ae956))
+- add ItemSkeleton component ([9277779](https://github.com/graasp/graasp-ui/commit/92777792a87f4ddeadc6f8191f5a403aa961713e))
+- add left and right content to header ([53f8eb0](https://github.com/graasp/graasp-ui/commit/53f8eb066ac5cca676f34fa6339a6a11675f4c4d))
+- add like button ([d635ae4](https://github.com/graasp/graasp-ui/commit/d635ae427d80aea5498816e4868582bf223d1aaf))
+- add link button for iframe ([d8c4568](https://github.com/graasp/graasp-ui/commit/d8c45686417108e343fad08cd489b0e90901284d))
+- add link to storybook, add showIframe and showButton booleans ([#162](https://github.com/graasp/graasp-ui/issues/162)) ([13ae642](https://github.com/graasp/graasp-ui/commit/13ae642e8cfbb9e23404a540b168331a32fe6c8a))
+- add Main, MainMenu, DrawerHeader and Sidebar components, tests ([d47b1db](https://github.com/graasp/graasp-ui/commit/d47b1dbd16d575f8583d651cd6382ab7444e972c))
+- add message to update app settings ([644fb1d](https://github.com/graasp/graasp-ui/commit/644fb1d22e77244b50fa64da1ffcdab3cf429694))
+- add more headings and fonts for text editor ([3912f14](https://github.com/graasp/graasp-ui/commit/3912f147f6893e212b2d69d9f37ef22bb09ae7b6))
+- add settings update ([7a18bdb](https://github.com/graasp/graasp-ui/commit/7a18bdb2d5d344071a7c8c3683f9c5cf22221253))
+- add size in thumbnail and avatar ([ecac066](https://github.com/graasp/graasp-ui/commit/ecac066cfdc4520337751a975cf4c215b80778d0))
+- add support for audio files ([5990152](https://github.com/graasp/graasp-ui/commit/5990152ea10ec9a38501bd486cfe0d836750459f))
+- add thumbnail and avatar components ([9241091](https://github.com/graasp/graasp-ui/commit/9241091895e195401419b144cb54e54ce11cc876))
+- add withResize variable height ([aa79f19](https://github.com/graasp/graasp-ui/commit/aa79f19c23e1ce855462936dc966f4577816b11d))
+- change icon to star ([e71bb5e](https://github.com/graasp/graasp-ui/commit/e71bb5ef917f34a288eaa3c0122c922a583a48a2))
+- extension feature to links and apps ([3f445de](https://github.com/graasp/graasp-ui/commit/3f445debf7443eb30e6f272f9c62e68d9690b7c2))
+- set up first components Loader and Header (tbd) ([5ae9105](https://github.com/graasp/graasp-ui/commit/5ae910511c3126d33ae743aa7b73bb91f0ceb12f))
+- update graasp logo, add navigation component ([edf2cab](https://github.com/graasp/graasp-ui/commit/edf2cab70c2958d4a730d491cc696138c1bf2b69))
 
 ### Bug Fixes
 
-* add buttonColor to prop ([e23d570](https://github.com/graasp/graasp-ui/commit/e23d5706ec43e7817254ceb454d9e8a251cffb44))
-* add withCollapse function and minor changes ([9fbe01e](https://github.com/graasp/graasp-ui/commit/9fbe01e4304ffdd31bff7d5c209fc2e485c0aec9))
-* avoid scrolling on copy/paste ([38394a6](https://github.com/graasp/graasp-ui/commit/38394a6440481f42922d876ac9cfa6847fec8442))
-* change class name ([75b4e69](https://github.com/graasp/graasp-ui/commit/75b4e69a8806de8505978c8b06a9b0de90c7db8f))
-* change classname to props ([45cb4d0](https://github.com/graasp/graasp-ui/commit/45cb4d0122c0075a2e9d7a3982bbe63c220b1f6c))
-* change CustomInitialLoader style ([781259f](https://github.com/graasp/graasp-ui/commit/781259fa45b92027eedd6eb24b184fd35765215d))
-* change export name ([f232f7f](https://github.com/graasp/graasp-ui/commit/f232f7fcc14af3f3af9f8976ab3fc676d4dfc9b5))
-* changes by review ([a748b77](https://github.com/graasp/graasp-ui/commit/a748b77c6508f96c7ae85e2fe228a732159acf04))
-* changes by review ([cd1c0cb](https://github.com/graasp/graasp-ui/commit/cd1c0cb6ebe3f90147e023523541b50e067a58a3))
-* changes by review ([21288c1](https://github.com/graasp/graasp-ui/commit/21288c196994ce3f7ab8aa5337b1c7ed865c83cf))
-* changes by review ([aa0b16e](https://github.com/graasp/graasp-ui/commit/aa0b16ebae0b0593d9b08f637cae4f1a1f00c0d9))
-* changes by review ([63d601d](https://github.com/graasp/graasp-ui/commit/63d601d5d1770ef3267aeb94596d97577b589ff3))
-* controll height with React state ([4244c3c](https://github.com/graasp/graasp-ui/commit/4244c3c01b78631b81ddf0150649a1fca5909448))
-* export new component ([adcd4ae](https://github.com/graasp/graasp-ui/commit/adcd4aeca50f30cf8de0ef94e1259689ed774489))
-* fix bug ([b33fed8](https://github.com/graasp/graasp-ui/commit/b33fed8bcb6d200fe5385598a3f9b302ce90225c))
-* fix code style ([849cb00](https://github.com/graasp/graasp-ui/commit/849cb0043ac5bfd6410b6e9e5311c898fb05abb1))
-* fix example with Header ([c9632c2](https://github.com/graasp/graasp-ui/commit/c9632c25f51c3ae3775b7d452c01ec3f059faa24))
-* fix like and unlike order ([0d91a56](https://github.com/graasp/graasp-ui/commit/0d91a5667e27d39d959e024cdbb79f90ab1e0003))
-* improve style ([e0d0999](https://github.com/graasp/graasp-ui/commit/e0d0999fff1d94a325d5e3b867f6b21019253ec1))
-* minor change ([92c916a](https://github.com/graasp/graasp-ui/commit/92c916a171224eeb33a197d32c4d3ed7f9e5dea1))
-* minor change ([a454e29](https://github.com/graasp/graasp-ui/commit/a454e298e694a1282252e48a39b5469ef08ba44c))
-* PDF visualization with Collapse ([e4ebca5](https://github.com/graasp/graasp-ui/commit/e4ebca5f4d67f296964907c10659bbf91b1ba6f7))
-* refactor AppItem as Component, reset channel, avoid rendering ([750d2fd](https://github.com/graasp/graasp-ui/commit/750d2fd7f0a9ea934ac542f834b29ab7b85bfd2b))
-* remove dash ([4efc54d](https://github.com/graasp/graasp-ui/commit/4efc54d77a2ff6b070ace66bc1076445b0cda0b1))
-* remove default values withResizing ([bffcfd9](https://github.com/graasp/graasp-ui/commit/bffcfd97542fb78d21e9940a3c3e3def38b85b1f))
-* remove default values withResizing ([6b184b3](https://github.com/graasp/graasp-ui/commit/6b184b38ec57aac684480e440f76234d5f90edde))
-* remove error message when loading files ([#118](https://github.com/graasp/graasp-ui/issues/118)) ([ae2748b](https://github.com/graasp/graasp-ui/commit/ae2748b590cb945ec9d4668707c72df61c584186))
-* remove postinstall script ([b7482c7](https://github.com/graasp/graasp-ui/commit/b7482c7b1acc06239b67d07eeb471ee021a52ca8))
-* remove user select highlight when using Resizing ([ec43d6f](https://github.com/graasp/graasp-ui/commit/ec43d6fd4a3a158638c9c7ed1a66b1ca066b5867))
-* rename to fileAudio ([b96b56b](https://github.com/graasp/graasp-ui/commit/b96b56b46a124cb5fd830b33dd6494b12f437380))
-* revert typing prop in package ([620378d](https://github.com/graasp/graasp-ui/commit/620378d7293dc68b5d1b3202fe35c9bbcffa42ee))
-* set color, fix types ([00f1636](https://github.com/graasp/graasp-ui/commit/00f16360e81086e42f0c70950b3afd66a9a36883))
-* set height depending on showCollapse ([95eb359](https://github.com/graasp/graasp-ui/commit/95eb3595e74d559b6afd3ae6571589fd0b15736d))
-* solve CustomInitialLoader css style ([96a2b1c](https://github.com/graasp/graasp-ui/commit/96a2b1c345ba2258cf8f987930d2f5f1b99c0ff1))
-* solve Thumbnail issue, refactor extra props, and minor changes ([87f746f](https://github.com/graasp/graasp-ui/commit/87f746f144a53c0b3887074a3651d484206fd49a))
-* solve UserSwitch feature ([72b1e79](https://github.com/graasp/graasp-ui/commit/72b1e79ab868d5e06c4ee5630d5547e647aff285))
-* **textEditor:** add matchVisual false, split cancel and save buttons ([c59c0f2](https://github.com/graasp/graasp-ui/commit/c59c0f2e566f61fe28cc6fa406af3bf0f9fb465d))
-* update TextEditor content when initialValue changes ([c502bf4](https://github.com/graasp/graasp-ui/commit/c502bf4d6532faf2eebfc2be9ce4f3526c6a3fbf))
-* update yarn.lock ([548430b](https://github.com/graasp/graasp-ui/commit/548430bac8be4890c363149f01213e64b29a934e))
-* use react-query type for Avatar ([0240505](https://github.com/graasp/graasp-ui/commit/0240505ed15be5205767d372900a61d662b9b965))
-* useAvatar type and typings in package ([df443f4](https://github.com/graasp/graasp-ui/commit/df443f4e3a57781db9ee1142dff506a046eee888))
-
+- add buttonColor to prop ([e23d570](https://github.com/graasp/graasp-ui/commit/e23d5706ec43e7817254ceb454d9e8a251cffb44))
+- add withCollapse function and minor changes ([9fbe01e](https://github.com/graasp/graasp-ui/commit/9fbe01e4304ffdd31bff7d5c209fc2e485c0aec9))
+- avoid scrolling on copy/paste ([38394a6](https://github.com/graasp/graasp-ui/commit/38394a6440481f42922d876ac9cfa6847fec8442))
+- change class name ([75b4e69](https://github.com/graasp/graasp-ui/commit/75b4e69a8806de8505978c8b06a9b0de90c7db8f))
+- change classname to props ([45cb4d0](https://github.com/graasp/graasp-ui/commit/45cb4d0122c0075a2e9d7a3982bbe63c220b1f6c))
+- change CustomInitialLoader style ([781259f](https://github.com/graasp/graasp-ui/commit/781259fa45b92027eedd6eb24b184fd35765215d))
+- change export name ([f232f7f](https://github.com/graasp/graasp-ui/commit/f232f7fcc14af3f3af9f8976ab3fc676d4dfc9b5))
+- changes by review ([a748b77](https://github.com/graasp/graasp-ui/commit/a748b77c6508f96c7ae85e2fe228a732159acf04))
+- changes by review ([cd1c0cb](https://github.com/graasp/graasp-ui/commit/cd1c0cb6ebe3f90147e023523541b50e067a58a3))
+- changes by review ([21288c1](https://github.com/graasp/graasp-ui/commit/21288c196994ce3f7ab8aa5337b1c7ed865c83cf))
+- changes by review ([aa0b16e](https://github.com/graasp/graasp-ui/commit/aa0b16ebae0b0593d9b08f637cae4f1a1f00c0d9))
+- changes by review ([63d601d](https://github.com/graasp/graasp-ui/commit/63d601d5d1770ef3267aeb94596d97577b589ff3))
+- controll height with React state ([4244c3c](https://github.com/graasp/graasp-ui/commit/4244c3c01b78631b81ddf0150649a1fca5909448))
+- export new component ([adcd4ae](https://github.com/graasp/graasp-ui/commit/adcd4aeca50f30cf8de0ef94e1259689ed774489))
+- fix bug ([b33fed8](https://github.com/graasp/graasp-ui/commit/b33fed8bcb6d200fe5385598a3f9b302ce90225c))
+- fix code style ([849cb00](https://github.com/graasp/graasp-ui/commit/849cb0043ac5bfd6410b6e9e5311c898fb05abb1))
+- fix example with Header ([c9632c2](https://github.com/graasp/graasp-ui/commit/c9632c25f51c3ae3775b7d452c01ec3f059faa24))
+- fix like and unlike order ([0d91a56](https://github.com/graasp/graasp-ui/commit/0d91a5667e27d39d959e024cdbb79f90ab1e0003))
+- improve style ([e0d0999](https://github.com/graasp/graasp-ui/commit/e0d0999fff1d94a325d5e3b867f6b21019253ec1))
+- minor change ([92c916a](https://github.com/graasp/graasp-ui/commit/92c916a171224eeb33a197d32c4d3ed7f9e5dea1))
+- minor change ([a454e29](https://github.com/graasp/graasp-ui/commit/a454e298e694a1282252e48a39b5469ef08ba44c))
+- PDF visualization with Collapse ([e4ebca5](https://github.com/graasp/graasp-ui/commit/e4ebca5f4d67f296964907c10659bbf91b1ba6f7))
+- refactor AppItem as Component, reset channel, avoid rendering ([750d2fd](https://github.com/graasp/graasp-ui/commit/750d2fd7f0a9ea934ac542f834b29ab7b85bfd2b))
+- remove dash ([4efc54d](https://github.com/graasp/graasp-ui/commit/4efc54d77a2ff6b070ace66bc1076445b0cda0b1))
+- remove default values withResizing ([bffcfd9](https://github.com/graasp/graasp-ui/commit/bffcfd97542fb78d21e9940a3c3e3def38b85b1f))
+- remove default values withResizing ([6b184b3](https://github.com/graasp/graasp-ui/commit/6b184b38ec57aac684480e440f76234d5f90edde))
+- remove error message when loading files ([#118](https://github.com/graasp/graasp-ui/issues/118)) ([ae2748b](https://github.com/graasp/graasp-ui/commit/ae2748b590cb945ec9d4668707c72df61c584186))
+- remove postinstall script ([b7482c7](https://github.com/graasp/graasp-ui/commit/b7482c7b1acc06239b67d07eeb471ee021a52ca8))
+- remove user select highlight when using Resizing ([ec43d6f](https://github.com/graasp/graasp-ui/commit/ec43d6fd4a3a158638c9c7ed1a66b1ca066b5867))
+- rename to fileAudio ([b96b56b](https://github.com/graasp/graasp-ui/commit/b96b56b46a124cb5fd830b33dd6494b12f437380))
+- revert typing prop in package ([620378d](https://github.com/graasp/graasp-ui/commit/620378d7293dc68b5d1b3202fe35c9bbcffa42ee))
+- set color, fix types ([00f1636](https://github.com/graasp/graasp-ui/commit/00f16360e81086e42f0c70950b3afd66a9a36883))
+- set height depending on showCollapse ([95eb359](https://github.com/graasp/graasp-ui/commit/95eb3595e74d559b6afd3ae6571589fd0b15736d))
+- solve CustomInitialLoader css style ([96a2b1c](https://github.com/graasp/graasp-ui/commit/96a2b1c345ba2258cf8f987930d2f5f1b99c0ff1))
+- solve Thumbnail issue, refactor extra props, and minor changes ([87f746f](https://github.com/graasp/graasp-ui/commit/87f746f144a53c0b3887074a3651d484206fd49a))
+- solve UserSwitch feature ([72b1e79](https://github.com/graasp/graasp-ui/commit/72b1e79ab868d5e06c4ee5630d5547e647aff285))
+- **textEditor:** add matchVisual false, split cancel and save buttons ([c59c0f2](https://github.com/graasp/graasp-ui/commit/c59c0f2e566f61fe28cc6fa406af3bf0f9fb465d))
+- update TextEditor content when initialValue changes ([c502bf4](https://github.com/graasp/graasp-ui/commit/c502bf4d6532faf2eebfc2be9ce4f3526c6a3fbf))
+- update yarn.lock ([548430b](https://github.com/graasp/graasp-ui/commit/548430bac8be4890c363149f01213e64b29a934e))
+- use react-query type for Avatar ([0240505](https://github.com/graasp/graasp-ui/commit/0240505ed15be5205767d372900a61d662b9b965))
+- useAvatar type and typings in package ([df443f4](https://github.com/graasp/graasp-ui/commit/df443f4e3a57781db9ee1142dff506a046eee888))
 
 ### Documentation
 
-* add license ([eebd9c3](https://github.com/graasp/graasp-ui/commit/eebd9c3a093291ff7e6f0f1a0428b5cddbdd8107))
-
+- add license ([eebd9c3](https://github.com/graasp/graasp-ui/commit/eebd9c3a093291ff7e6f0f1a0428b5cddbdd8107))
 
 ### Tests
 
-* map peerDependencies modules, export css ([fac2dd4](https://github.com/graasp/graasp-ui/commit/fac2dd41c6ec48ee0f592139dea1a635988cc5bd))
-* run test with jest ([a8b57ff](https://github.com/graasp/graasp-ui/commit/a8b57ffe073eb78597e61119b72b493b9a213368))
-
+- map peerDependencies modules, export css ([fac2dd4](https://github.com/graasp/graasp-ui/commit/fac2dd41c6ec48ee0f592139dea1a635988cc5bd))
+- run test with jest ([a8b57ff](https://github.com/graasp/graasp-ui/commit/a8b57ffe073eb78597e61119b72b493b9a213368))
 
 ### Build System
 
-* **example:** add material as dependencies ([d7cdbb0](https://github.com/graasp/graasp-ui/commit/d7cdbb0fbf4b20475864a56ecafd685af0766978))
-* move material dependencies to peer dependencies ([d73bd0e](https://github.com/graasp/graasp-ui/commit/d73bd0ed26c6e9dfb8fa9d7e09b63f858d2e89c2))
-* output cjs ([d0234a6](https://github.com/graasp/graasp-ui/commit/d0234a6afcbe0e4525bddfca0cbb89b63e3db9bc))
-* update dependencies ([b3f2f84](https://github.com/graasp/graasp-ui/commit/b3f2f84d6ac9653f74fae708850f36a7df325776))
-* update dependencies ([6be6d53](https://github.com/graasp/graasp-ui/commit/6be6d536a190873a3a2eddb1c7020909f2fc8a0b))
-* use rollup, remove d.ts ([522977a](https://github.com/graasp/graasp-ui/commit/522977a4c529ccbcee50aaea5bf272b4d1432cb1))
-
+- **example:** add material as dependencies ([d7cdbb0](https://github.com/graasp/graasp-ui/commit/d7cdbb0fbf4b20475864a56ecafd685af0766978))
+- move material dependencies to peer dependencies ([d73bd0e](https://github.com/graasp/graasp-ui/commit/d73bd0ed26c6e9dfb8fa9d7e09b63f858d2e89c2))
+- output cjs ([d0234a6](https://github.com/graasp/graasp-ui/commit/d0234a6afcbe0e4525bddfca0cbb89b63e3db9bc))
+- update dependencies ([b3f2f84](https://github.com/graasp/graasp-ui/commit/b3f2f84d6ac9653f74fae708850f36a7df325776))
+- update dependencies ([6be6d53](https://github.com/graasp/graasp-ui/commit/6be6d536a190873a3a2eddb1c7020909f2fc8a0b))
+- use rollup, remove d.ts ([522977a](https://github.com/graasp/graasp-ui/commit/522977a4c529ccbcee50aaea5bf272b4d1432cb1))
 
 ### Continuous Integration
 
-* add github pages deployment workflow ([8681092](https://github.com/graasp/graasp-ui/commit/86810928e2fa1cc91415dccc048d248d7ec108d5))
-* add test workflow ([4583daa](https://github.com/graasp/graasp-ui/commit/4583daa1bfd4d6c1aebb8976cd43b31eb500b082))
-* add workflow to publish to npm ([8d550df](https://github.com/graasp/graasp-ui/commit/8d550dfcd0ea786ceaab7ee6f69c7ea7035d9d15))
-* set up storybook for button ([5f313b0](https://github.com/graasp/graasp-ui/commit/5f313b018202f53d95319cc97d019ea1f37dcea0))
-* upgrade yarn to version 2 ([25897cf](https://github.com/graasp/graasp-ui/commit/25897cf87500052bdc4230f70357c2efa6d7eaeb))
+- add github pages deployment workflow ([8681092](https://github.com/graasp/graasp-ui/commit/86810928e2fa1cc91415dccc048d248d7ec108d5))
+- add test workflow ([4583daa](https://github.com/graasp/graasp-ui/commit/4583daa1bfd4d6c1aebb8976cd43b31eb500b082))
+- add workflow to publish to npm ([8d550df](https://github.com/graasp/graasp-ui/commit/8d550dfcd0ea786ceaab7ee6f69c7ea7035d9d15))
+- set up storybook for button ([5f313b0](https://github.com/graasp/graasp-ui/commit/5f313b018202f53d95319cc97d019ea1f37dcea0))
+- upgrade yarn to version 2 ([25897cf](https://github.com/graasp/graasp-ui/commit/25897cf87500052bdc4230f70357c2efa6d7eaeb))
 
 ## [0.2.0](https://github.com/graasp/graasp-ui/compare/v0.1.1...v0.2.0) (2020-08-05)
 
-
 ### ⚠ BREAKING CHANGES
 
-* update example props
+- update example props
 
 ### Features
 
-* update example props ([3d62ecf](https://github.com/graasp/graasp-ui/commit/3d62ecfce4de56063fb386caa89a8294a098c14f))
+- update example props ([3d62ecf](https://github.com/graasp/graasp-ui/commit/3d62ecfce4de56063fb386caa89a8294a098c14f))
 
 ### [0.1.1](https://github.com/graasp/graasp-ui/compare/v0.1.0...v0.1.1) (2020-08-05)
 
-
 ### Build System
 
-* release with standard version ([8fcbba2](https://github.com/graasp/graasp-ui/commit/8fcbba2559e2d43b9be96e90b5494433a0aca2d5))
+- release with standard version ([8fcbba2](https://github.com/graasp/graasp-ui/commit/8fcbba2559e2d43b9be96e90b5494433a0aca2d5))

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@ag-grid-community/react": "^31.0.3",
     "@ag-grid-community/styles": "^31.0.3",
     "@graasp/sdk": "3.8.3",
-    "@graasp/translations": "1.23.0",
     "@storybook/react-vite": "7.6.13",
     "http-status-codes": "2.3.0",
     "interweave": "13.1.0",

--- a/src/Collapse/Collapse.stories.tsx
+++ b/src/Collapse/Collapse.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import Collapse from './Collapse';
 
-const meta: Meta<typeof Collapse> = {
+const meta = {
   title: 'Common/Collapse',
   component: Collapse,
 
@@ -19,14 +19,14 @@ const meta: Meta<typeof Collapse> = {
       <img src='https://picsum.photos/100' />
     </Collapse>
   ),
-};
+} satisfies Meta<typeof Collapse>;
 
 export default meta;
 
-type Story = StoryObj<typeof Collapse>;
+type Story = StoryObj<typeof meta>;
 
-export const CollapsedImage: Story = {
+export const CollapsedImage = {
   args: {
     title: 'My collapsed element',
   },
-};
+} satisfies Story;

--- a/src/ItemBadges/ItemBadges.tsx
+++ b/src/ItemBadges/ItemBadges.tsx
@@ -1,4 +1,3 @@
-import Chat from '@mui/icons-material/Chat';
 import Public from '@mui/icons-material/Public';
 import PushPin from '@mui/icons-material/PushPin';
 import UnfoldLess from '@mui/icons-material/UnfoldLess';
@@ -7,6 +6,7 @@ import { Avatar, AvatarGroup, Tooltip } from '@mui/material';
 
 import { ThumbnailSize } from '@graasp/sdk';
 
+import { ChatboxButton } from '../buttons';
 import { LibraryIcon } from '../icons';
 
 type ItemBadgeProps = {
@@ -100,9 +100,16 @@ const ItemBadges = ({
           backgroundColor={backgroundColor}
           tooltip={showChatboxTooltip}
         >
-          <Chat
-            fontSize={ThumbnailSize.Small}
-            sx={{ width: 15, height: 15, marginLeft: '1px', marginTop: '2px' }}
+          <ChatboxButton
+            size='small'
+            showChat
+            sx={{
+              width: 15,
+              height: 15,
+              marginLeft: '1px',
+              marginTop: '2px',
+              color: 'white',
+            }}
           />
         </ItemBadge>
       )}

--- a/src/Navigation/Navigation.stories.tsx
+++ b/src/Navigation/Navigation.stories.tsx
@@ -7,39 +7,32 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import { BrowserRouter } from 'react-router-dom';
 
 import {
-  FolderItemType,
+  FolderItemFactory,
   ItemType,
+  LocalFileItemFactory,
   LocalFileItemType,
   MimeTypes,
 } from '@graasp/sdk';
-import { DEFAULT_LANG } from '@graasp/translations';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
 import HomeMenu from './HomeMenu';
 import ItemMenu, { ItemMenuProps } from './ItemMenu';
 import Navigation from './Navigation';
 
-const buildItem = (name: string): LocalFileItemType => ({
-  id: name,
-  name,
-  extra: {
-    [ItemType.LOCAL_FILE]: {
-      path: 'https://picsum.photos/100',
-      mimetype: MimeTypes.Image.PNG,
-      name: 'original file name',
-      size: 2600,
-      content: '',
+const buildItem = (name: string): LocalFileItemType =>
+  LocalFileItemFactory({
+    id: name,
+    name,
+    extra: {
+      [ItemType.LOCAL_FILE]: {
+        path: 'https://picsum.photos/100',
+        mimetype: MimeTypes.Image.PNG,
+        name: 'original file name',
+        size: 2600,
+        content: '',
+      },
     },
-  },
-  type: 'file',
-  description: 'my image description',
-  path: 'item-path',
-  settings: {},
-  lang: DEFAULT_LANG,
-  creator: MOCK_MEMBER,
-  createdAt: '2023-09-06T11:50:32.894Z',
-  updatedAt: '2023-09-06T11:50:32.894Z',
-});
+  });
 
 const meta: Meta<typeof Navigation> = {
   title: 'Common/Navigation',
@@ -69,7 +62,7 @@ const useChildren: ItemMenuProps['useChildren'] = (id) => {
 };
 const buildToItemPath = (id: string): string => id;
 const dataTestId = 'NavigateNextIcon';
-const folder: FolderItemType = {
+const folder = FolderItemFactory({
   id: 'folder-id',
   name: 'folder',
   extra: {
@@ -81,11 +74,8 @@ const folder: FolderItemType = {
   description: 'my image description',
   path: 'item-path',
   settings: {},
-  lang: DEFAULT_LANG,
   creator: MOCK_MEMBER,
-  createdAt: '2023-09-06T11:50:32.894Z',
-  updatedAt: '2023-09-06T11:50:32.894Z',
-};
+});
 
 const menu = [
   { name: 'Home', id: 'home', to: 'home' },

--- a/src/buttons/ChatboxButton/ChatboxButton.stories.tsx
+++ b/src/buttons/ChatboxButton/ChatboxButton.stories.tsx
@@ -4,31 +4,30 @@ import { userEvent, within } from '@storybook/testing-library';
 
 import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
-import PinButton from './PinButton';
+import ChatboxButton from './ChatboxButton';
 
-const meta: Meta<typeof PinButton> = {
-  title: 'Buttons/PinButton',
-  component: PinButton,
+const meta: Meta<typeof ChatboxButton> = {
+  title: 'Buttons/ChatboxButton',
+  component: ChatboxButton,
 
   argTypes: {
     onClick: {
-      action: 'pin',
+      action: 'show chat',
       table: {
         category: TABLE_CATEGORIES.EVENTS,
       },
     },
-    pinText: {},
   },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof PinButton>;
+type Story = StoryObj<typeof ChatboxButton>;
 
-export const IsPinned: Story = {
+export const ShowChat: Story = {
   args: {
-    isPinned: true,
-    color: 'primary',
+    showChat: true,
+    color: 'error',
   },
 };
 
@@ -41,12 +40,12 @@ export const Icon: Story = {
 export const MenuItem: Story = {
   args: {
     type: ActionButton.MENU_ITEM,
-    pinText: 'pin item',
+    showChatText: 'Show Chat',
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByText(args.pinText!));
+    await userEvent.click(canvas.getByText(args.showChatText!));
 
     expect(args.onClick).toHaveBeenCalled();
   },

--- a/src/buttons/ChatboxButton/ChatboxButton.stories.tsx
+++ b/src/buttons/ChatboxButton/ChatboxButton.stories.tsx
@@ -47,7 +47,7 @@ export const IconFalse: Story = {
 
 export const MenuItem = {
   args: {
-    showChat: true,
+    showChat: false,
     type: ActionButton.MENU_ITEM,
     showChatText: 'Show Chat',
   },

--- a/src/buttons/ChatboxButton/ChatboxButton.stories.tsx
+++ b/src/buttons/ChatboxButton/ChatboxButton.stories.tsx
@@ -6,7 +6,7 @@ import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import ChatboxButton from './ChatboxButton';
 
-const meta: Meta<typeof ChatboxButton> = {
+const meta = {
   title: 'Buttons/ChatboxButton',
   component: ChatboxButton,
 
@@ -18,11 +18,11 @@ const meta: Meta<typeof ChatboxButton> = {
       },
     },
   },
-};
+} satisfies Meta<typeof ChatboxButton>;
 
 export default meta;
 
-type Story = StoryObj<typeof ChatboxButton>;
+type Story = StoryObj<typeof meta>;
 
 export const ShowChat: Story = {
   args: {
@@ -33,12 +33,21 @@ export const ShowChat: Story = {
 
 export const Icon: Story = {
   args: {
+    showChat: true,
     type: ActionButton.ICON_BUTTON,
   },
 };
 
-export const MenuItem: Story = {
+export const IconFalse: Story = {
   args: {
+    showChat: false,
+    type: ActionButton.ICON_BUTTON,
+  },
+};
+
+export const MenuItem = {
+  args: {
+    showChat: true,
     type: ActionButton.MENU_ITEM,
     showChatText: 'Show Chat',
   },
@@ -49,4 +58,4 @@ export const MenuItem: Story = {
 
     expect(args.onClick).toHaveBeenCalled();
   },
-};
+} satisfies Story;

--- a/src/buttons/ChatboxButton/ChatboxButton.tsx
+++ b/src/buttons/ChatboxButton/ChatboxButton.tsx
@@ -1,23 +1,69 @@
-import { IconSizeVariant } from '@/types';
+import { ActionButton, ActionButtonVariant, IconSizeVariant } from '@/types';
 
-import ForumIcon from '@mui/icons-material/Forum';
-import { IconButton, Tooltip } from '@mui/material';
+import { Chat } from '@mui/icons-material';
+import SpeakerNotesOffIcon from '@mui/icons-material/SpeakerNotesOff';
+import { IconButton, SvgIconOwnProps, SxProps, Tooltip } from '@mui/material';
+
+import MenuItemButton from '../MenuItemButton';
 
 export type Props = {
   id?: string;
   onClick?: () => void;
   size?: IconSizeVariant;
   tooltip?: string;
+  menuItemClassName?: string;
+  showChat: boolean;
+  showChatText?: string;
+  hideChatText?: string;
+  type?: ActionButtonVariant;
+  color?: SvgIconOwnProps['color'];
+  sx?: SxProps;
 };
 
-const ChatboxButton = ({ tooltip, id, onClick, size }: Props): JSX.Element => (
-  <Tooltip title={tooltip}>
-    <span>
-      <IconButton id={id} onClick={onClick} size={size}>
-        <ForumIcon />
-      </IconButton>
-    </span>
-  </Tooltip>
-);
+const ChatboxButton = ({
+  tooltip,
+  showChat,
+  id,
+  onClick,
+  size,
+  menuItemClassName,
+  type,
+  showChatText = 'Show Chat',
+  hideChatText = 'Hide Chat',
+  color,
+  sx = {},
+}: Props): JSX.Element => {
+  const icon = showChat ? (
+    <Chat color={color} sx={sx} />
+  ) : (
+    <SpeakerNotesOffIcon color={color} sx={sx} />
+  );
+  const text = showChat ? hideChatText : showChatText;
+
+  switch (type) {
+    case ActionButton.ICON:
+      return icon;
+    case ActionButton.MENU_ITEM:
+      return (
+        <MenuItemButton
+          icon={icon}
+          text={text}
+          onClick={onClick}
+          className={menuItemClassName}
+        />
+      );
+    case ActionButton.ICON_BUTTON:
+    default:
+      return (
+        <Tooltip title={tooltip}>
+          <span>
+            <IconButton id={id} onClick={onClick} size={size}>
+              {icon}
+            </IconButton>
+          </span>
+        </Tooltip>
+      );
+  }
+};
 
 export default ChatboxButton;

--- a/src/buttons/CopyButton/CopyButton.stories.tsx
+++ b/src/buttons/CopyButton/CopyButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import CopyButton from './CopyButton';
 
@@ -45,7 +46,7 @@ type Story = StoryObj<typeof CopyButton>;
 export const Icon: Story = {
   args: {
     color: 'primary',
-    type: 'icon',
+    type: ActionButton.ICON_BUTTON,
     text: 'Copier',
   },
 };

--- a/src/buttons/CopyButton/CopyButton.stories.tsx
+++ b/src/buttons/CopyButton/CopyButton.stories.tsx
@@ -4,7 +4,7 @@ import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import CopyButton from './CopyButton';
 
-const meta: Meta<typeof CopyButton> = {
+const meta = {
   title: 'Buttons/CopyButton',
   component: CopyButton,
 
@@ -38,21 +38,21 @@ const meta: Meta<typeof CopyButton> = {
     },
   },
   render: (args) => <CopyButton {...args} />,
-};
+} satisfies Meta<typeof CopyButton>;
 
 export default meta;
-type Story = StoryObj<typeof CopyButton>;
+type Story = StoryObj<typeof meta>;
 
-export const Icon: Story = {
+export const Icon = {
   args: {
     color: 'primary',
     type: ActionButton.ICON_BUTTON,
     text: 'Copier',
   },
-};
+} satisfies Story;
 
-export const MenuItem: Story = {
+export const MenuItem = {
   args: {
     type: 'menuItem',
   },
-};
+} satisfies Story;

--- a/src/buttons/CopyButton/CopyButton.tsx
+++ b/src/buttons/CopyButton/CopyButton.tsx
@@ -22,7 +22,7 @@ const CopyButton = ({
   menuItemClassName,
   onClick,
   text = 'Copy',
-  type = 'icon',
+  type = ActionButton.ICON_BUTTON,
 }: Props): JSX.Element => {
   switch (type) {
     case ActionButton.MENU_ITEM:

--- a/src/buttons/DeleteButton/DeleteButton.tsx
+++ b/src/buttons/DeleteButton/DeleteButton.tsx
@@ -1,7 +1,7 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import { IconButton, ListItemIcon, MenuItem, Tooltip } from '@mui/material';
 
-import { FC, MouseEventHandler } from 'react';
+import { MouseEventHandler } from 'react';
 
 import { ActionButton, ActionButtonVariant, ColorVariants } from '../../types';
 
@@ -14,21 +14,22 @@ export type Props = {
   type?: ActionButtonVariant;
 };
 
-const DeleteButton: FC<Props> = ({
+const DeleteButton = ({
   className,
   color,
   id,
   onClick,
   text = 'Delete',
   type,
-}) => {
+}: Props): JSX.Element => {
+  const icon = <DeleteIcon />;
   switch (type) {
+    case ActionButton.ICON:
+      return icon;
     case ActionButton.MENU_ITEM:
       return (
         <MenuItem key={text} onClick={onClick}>
-          <ListItemIcon>
-            <DeleteIcon />
-          </ListItemIcon>
+          <ListItemIcon>{icon}</ListItemIcon>
           {text}
         </MenuItem>
       );
@@ -44,7 +45,7 @@ const DeleteButton: FC<Props> = ({
               aria-label={text}
               onClick={onClick}
             >
-              <DeleteIcon />
+              {icon}
             </IconButton>
           </span>
         </Tooltip>

--- a/src/buttons/DownloadButton/DownloadButton.tsx
+++ b/src/buttons/DownloadButton/DownloadButton.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
 } from '@mui/material';
 
-import { FC, MouseEventHandler } from 'react';
+import { MouseEventHandler } from 'react';
 
 import { DEFAULT_LOADER_SIZE } from '../../constants';
 import {
@@ -43,7 +43,7 @@ export interface DownloadButtonProps {
   type?: ActionButtonVariant;
 }
 
-const DownloadButton: FC<DownloadButtonProps> = ({
+const DownloadButton = ({
   ariaLabel = 'download',
   handleDownload,
   isLoading = false,
@@ -51,15 +51,16 @@ const DownloadButton: FC<DownloadButtonProps> = ({
   loaderSize = DEFAULT_LOADER_SIZE,
   title = 'Download',
   placement = 'bottom',
-  type = 'icon',
-}) => {
+  type = ActionButton.ICON_BUTTON,
+}: DownloadButtonProps): JSX.Element => {
+  const icon = <GetAppIcon />;
   switch (type) {
+    case ActionButton.ICON:
+      return icon;
     case ActionButton.MENU_ITEM:
       return (
         <MenuItem key={title} onClick={handleDownload}>
-          <ListItemIcon>
-            <GetAppIcon />
-          </ListItemIcon>
+          <ListItemIcon>{icon}</ListItemIcon>
           {title}
         </MenuItem>
       );
@@ -72,7 +73,7 @@ const DownloadButton: FC<DownloadButtonProps> = ({
         <Tooltip title={title} placement={placement}>
           <span>
             <IconButton onClick={handleDownload} aria-label={ariaLabel}>
-              <GetAppIcon />
+              {icon}
             </IconButton>
           </span>
         </Tooltip>

--- a/src/buttons/EditButton/EditButton.tsx
+++ b/src/buttons/EditButton/EditButton.tsx
@@ -34,13 +34,14 @@ const EditButton = ({
   size = 'small',
   type = ActionButton.ICON_BUTTON,
 }: Props): JSX.Element => {
+  const icon = <EditIcon />;
   switch (type) {
+    case ActionButton.ICON:
+      return icon;
     case ActionButton.MENU_ITEM:
       return (
         <MenuItem key={title} onClick={onClick} id={id} className={className}>
-          <ListItemIcon>
-            <EditIcon />
-          </ListItemIcon>
+          <ListItemIcon>{icon}</ListItemIcon>
           <ListItemText>{title}</ListItemText>
         </MenuItem>
       );
@@ -56,7 +57,7 @@ const EditButton = ({
               onClick={onClick}
               size={size}
             >
-              <EditIcon />
+              {icon}
             </IconButton>
           </span>
         </Tooltip>

--- a/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
+++ b/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
@@ -1,12 +1,12 @@
 import { expect } from '@storybook/jest';
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { userEvent, within } from '@storybook/testing-library';
 
 import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import FavoriteButton from './FavoriteButton';
 
-export default {
+const meta = {
   title: 'Buttons/FavoriteButton',
   component: FavoriteButton,
 
@@ -34,19 +34,21 @@ export default {
       },
     },
   },
-};
+} satisfies Meta<typeof FavoriteButton>;
 
-type Story = StoryObj<typeof FavoriteButton>;
+export default meta;
 
-export const Default: Story = {
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
   args: {},
-};
+} satisfies Story;
 
-export const IsFavorite: Story = {
+export const IsFavorite = {
   args: { isFavorite: true },
-};
+} satisfies Story;
 
-export const MenuItem: Story = {
+export const MenuItem = {
   args: {
     text: 'Add to Favorites',
     type: ActionButton.MENU_ITEM,
@@ -58,4 +60,4 @@ export const MenuItem: Story = {
 
     expect(args.handleFavorite).toHaveBeenCalled();
   },
-};
+} satisfies Story;

--- a/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
+++ b/src/buttons/FavoriteButton/FavoriteButton.stories.tsx
@@ -1,4 +1,6 @@
+import { expect } from '@storybook/jest';
 import type { StoryObj } from '@storybook/react';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
@@ -48,5 +50,12 @@ export const MenuItem: Story = {
   args: {
     text: 'Add to Favorites',
     type: ActionButton.MENU_ITEM,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByText(args.text!));
+
+    expect(args.handleFavorite).toHaveBeenCalled();
   },
 };

--- a/src/buttons/FavoriteButton/FavoriteButton.tsx
+++ b/src/buttons/FavoriteButton/FavoriteButton.tsx
@@ -1,17 +1,12 @@
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
-import {
-  IconButton,
-  ListItemIcon,
-  MenuItem,
-  SvgIconProps,
-  Tooltip,
-} from '@mui/material';
+import { IconButton, SvgIconProps, Tooltip } from '@mui/material';
 import { SxProps } from '@mui/material/styles';
 
-import { FC, MouseEventHandler } from 'react';
+import { MouseEventHandler } from 'react';
 
 import { ActionButton, ActionButtonVariant, ColorVariants } from '../../types';
+import MenuItemButton from '../MenuItemButton';
 
 const FAVORITE_COLOR = '#ffc107';
 
@@ -35,10 +30,10 @@ export interface FavoriteButtonProps {
   text?: string;
 }
 
-const FavoriteButton: FC<FavoriteButtonProps> = ({
+const FavoriteButton = ({
   ariaLabel = 'favorite',
   className,
-  color = 'default',
+  color = 'inherit',
   handleFavorite,
   handleUnfavorite,
   isFavorite = false,
@@ -47,7 +42,7 @@ const FavoriteButton: FC<FavoriteButtonProps> = ({
   text,
   tooltip,
   type,
-}) => {
+}: FavoriteButtonProps): JSX.Element => {
   const icon = isFavorite ? (
     <StarIcon fontSize={size} />
   ) : (
@@ -62,12 +57,17 @@ const FavoriteButton: FC<FavoriteButtonProps> = ({
   const onClick = isFavorite ? handleUnfavorite : handleFavorite;
 
   switch (type) {
+    case ActionButton.ICON:
+      return icon;
     case ActionButton.MENU_ITEM:
       return (
-        <MenuItem key={text} onClick={onClick} className={className}>
-          <ListItemIcon color={iconColor}>{icon}</ListItemIcon>
-          {text}
-        </MenuItem>
+        <MenuItemButton
+          iconColor={iconColor}
+          text={text ?? tooltipText}
+          onClick={onClick}
+          icon={icon}
+          className={className}
+        />
       );
     case ActionButton.ICON_BUTTON:
     default:

--- a/src/buttons/MenuItemButton.tsx
+++ b/src/buttons/MenuItemButton.tsx
@@ -1,0 +1,40 @@
+import { ListItemText } from '@mui/material';
+import ListItemIcon, { ListItemIconProps } from '@mui/material/ListItemIcon';
+import MenuItem from '@mui/material/MenuItem';
+
+import { MouseEventHandler } from 'react';
+
+export type MenuItemButtonProps = {
+  className?: string;
+  onClick?: MouseEventHandler;
+  text: string;
+  icon: JSX.Element;
+  iconColor?: ListItemIconProps['color'];
+};
+
+const MenuItemButton = ({
+  text,
+  icon,
+  onClick,
+  className,
+  iconColor = 'default',
+}: MenuItemButtonProps): JSX.Element => {
+  return (
+    <MenuItem key={text} onClick={onClick} className={className}>
+      <ListItemIcon color={iconColor}>{icon}</ListItemIcon>
+      <ListItemText
+        sx={{
+          '.MuiListItemText-primary, .MuiListItemText-secondary': {
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+          },
+        }}
+      >
+        {text}
+      </ListItemText>
+    </MenuItem>
+  );
+};
+
+export default MenuItemButton;

--- a/src/buttons/MoveButton/MoveButton.tsx
+++ b/src/buttons/MoveButton/MoveButton.tsx
@@ -29,13 +29,14 @@ const MoveButton = ({
   text = 'Move',
   type = ActionButton.ICON_BUTTON,
 }: MoveButtonProps): JSX.Element => {
+  const icon = <OpenWith />;
   switch (type) {
+    case ActionButton.ICON:
+      return icon;
     case ActionButton.MENU_ITEM:
       return (
         <MenuItem key={text} onClick={onClick} className={menuItemClassName}>
-          <ListItemIcon>
-            <OpenWith />
-          </ListItemIcon>
+          <ListItemIcon>{icon}</ListItemIcon>
           {text}
         </MenuItem>
       );
@@ -52,7 +53,7 @@ const MoveButton = ({
               aria-label={text}
               onClick={onClick}
             >
-              <OpenWith />
+              {icon}
             </IconButton>
           </span>
         </Tooltip>

--- a/src/buttons/PinButton/PinButton.stories.tsx
+++ b/src/buttons/PinButton/PinButton.stories.tsx
@@ -6,7 +6,7 @@ import { ActionButton } from '../../types';
 import { TABLE_CATEGORIES } from '../../utils/storybook';
 import PinButton from './PinButton';
 
-const meta: Meta<typeof PinButton> = {
+const meta = {
   title: 'Buttons/PinButton',
   component: PinButton,
 
@@ -19,26 +19,26 @@ const meta: Meta<typeof PinButton> = {
     },
     pinText: {},
   },
-};
+} satisfies Meta<typeof PinButton>;
 
 export default meta;
 
-type Story = StoryObj<typeof PinButton>;
+type Story = StoryObj<typeof meta>;
 
-export const IsPinned: Story = {
+export const IsPinned = {
   args: {
     isPinned: true,
     color: 'primary',
   },
-};
+} satisfies Story;
 
-export const Icon: Story = {
+export const Icon = {
   args: {
     type: ActionButton.ICON_BUTTON,
   },
-};
+} satisfies Story;
 
-export const MenuItem: Story = {
+export const MenuItem = {
   args: {
     type: ActionButton.MENU_ITEM,
     pinText: 'pin item',
@@ -50,4 +50,4 @@ export const MenuItem: Story = {
 
     expect(args.onClick).toHaveBeenCalled();
   },
-};
+} satisfies Story;

--- a/src/buttons/PinButton/PinButton.tsx
+++ b/src/buttons/PinButton/PinButton.tsx
@@ -1,14 +1,18 @@
 import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
-import { IconButton, ListItemIcon, MenuItem, Tooltip } from '@mui/material';
+import { SvgIconOwnProps } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 
 import {
   ActionButton,
   ActionButtonVariant,
   IconSizeVariant,
 } from '../../types';
+import MenuItemButton from '../MenuItemButton';
 
 export type PinButtonProps = {
+  color?: SvgIconOwnProps['color'];
   iconClassName?: string;
   id?: string;
   isPinned?: boolean;
@@ -29,20 +33,29 @@ const PinButton = ({
   pinText = 'Pin',
   unPinText = 'Unpin',
   size,
+  color,
 }: PinButtonProps): JSX.Element => {
-  const icon = isPinned ? <PushPinIcon /> : <PushPinOutlinedIcon />;
+  const icon = isPinned ? (
+    <PushPinIcon color={color} />
+  ) : (
+    <PushPinOutlinedIcon color={color} />
+  );
   const text = isPinned ? unPinText : pinText;
 
   switch (type) {
+    case ActionButton.ICON:
+      return icon;
     case ActionButton.MENU_ITEM:
       return (
-        <MenuItem key={text} onClick={onClick} className={menuItemClassName}>
-          <ListItemIcon>{icon}</ListItemIcon>
-          {text}
-        </MenuItem>
+        <MenuItemButton
+          icon={icon}
+          onClick={onClick}
+          text={text}
+          className={menuItemClassName}
+        />
       );
-    default:
     case ActionButton.ICON_BUTTON:
+    default:
       return (
         <Tooltip title={text}>
           <span>

--- a/src/buttons/ShareButton/ShareButton.tsx
+++ b/src/buttons/ShareButton/ShareButton.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from '@mui/material';
 
-import { FC, MouseEventHandler } from 'react';
+import { MouseEventHandler } from 'react';
 
 import { ActionButton, ActionButtonVariant } from '../../types';
 
@@ -24,7 +24,7 @@ export type Props = {
   type?: ActionButtonVariant;
 };
 
-const ShareButton: FC<Props> = ({
+const ShareButton = ({
   open,
   className,
   tooltip = 'Share',
@@ -33,14 +33,15 @@ const ShareButton: FC<Props> = ({
   onClick,
   size,
   type = ActionButton.ICON_BUTTON,
-}) => {
+}: Props): JSX.Element => {
+  const icon = open ? <CloseIcon /> : <Groups />;
   switch (type) {
+    case ActionButton.ICON:
+      return icon;
     case ActionButton.MENU_ITEM:
       return (
         <MenuItem key={tooltip} className={className} onClick={onClick}>
-          <ListItemIcon>
-            <Groups />
-          </ListItemIcon>
+          <ListItemIcon>{icon}</ListItemIcon>
           <ListItemText>{tooltip}</ListItemText>
         </MenuItem>
       );
@@ -56,7 +57,7 @@ const ShareButton: FC<Props> = ({
               id={id}
               size={size}
             >
-              {open ? <CloseIcon /> : <Groups />}
+              {icon}
             </IconButton>
           </span>
         </Tooltip>

--- a/src/items/AppItem.stories.tsx
+++ b/src/items/AppItem.stories.tsx
@@ -2,8 +2,7 @@ import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
 import { within } from '@storybook/testing-library';
 
-import { ItemType } from '@graasp/sdk';
-import { DEFAULT_LANG } from '@graasp/translations';
+import { AppItemFactory, ItemType } from '@graasp/sdk';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
 import AppItem from './AppItem';
@@ -19,7 +18,7 @@ type Story = StoryObj<typeof AppItem>;
 
 export const Example: Story = {
   args: {
-    item: {
+    item: AppItemFactory({
       name: 'my app',
       id: 'item-id',
       description: 'item-description',
@@ -31,11 +30,8 @@ export const Example: Story = {
       type: 'app',
       path: 'item-path',
       settings: {},
-      lang: DEFAULT_LANG,
       creator: MOCK_MEMBER,
-      createdAt: '2023-09-06T11:50:32.894Z',
-      updatedAt: '2023-09-06T11:50:32.894Z',
-    },
+    }),
   },
 };
 

--- a/src/items/AppItem.stories.tsx
+++ b/src/items/AppItem.stories.tsx
@@ -2,21 +2,26 @@ import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
 import { within } from '@storybook/testing-library';
 
-import { AppItemFactory, ItemType } from '@graasp/sdk';
+import {
+  AppItemFactory,
+  Context,
+  ItemType,
+  PermissionLevel,
+} from '@graasp/sdk';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
 import AppItem from './AppItem';
 
-const meta: Meta<typeof AppItem> = {
+const meta = {
   title: 'Items/AppItem',
   component: AppItem,
-};
+} satisfies Meta<typeof AppItem>;
 
 export default meta;
 
-type Story = StoryObj<typeof AppItem>;
+type Story = StoryObj<typeof meta>;
 
-export const Example: Story = {
+export const Example = {
   args: {
     item: AppItemFactory({
       name: 'my app',
@@ -32,13 +37,21 @@ export const Example: Story = {
       settings: {},
       creator: MOCK_MEMBER,
     }),
+    requestApiAccessToken: async () => ({ token: 'token' }),
+    contextPayload: {
+      apiHost: 'apiHost',
+      itemId: 'itemId',
+      settings: {},
+      permission: PermissionLevel.Read,
+      lang: 'en',
+      context: Context.Library,
+    },
   },
-};
-
-Example.play = async ({ canvasElement, args }) => {
-  const canvas = within(canvasElement);
-  if (args.item.description) {
-    await expect(canvas.getByText(args.item.description)).toBeInTheDocument();
-  }
-  await expect(canvas.getByTitle(args.item.name)).toBeInTheDocument();
-};
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    if (args.item.description) {
+      await expect(canvas.getByText(args.item.description)).toBeInTheDocument();
+    }
+    await expect(canvas.getByTitle(args.item.name)).toBeInTheDocument();
+  },
+} satisfies Story;

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -11,7 +11,7 @@ import { MOCK_MEMBER } from '../utils/fixtures';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import FileItem from './FileItem';
 
-const meta: Meta<typeof FileItem> = {
+const meta = {
   title: 'Items/FileItem',
   component: FileItem,
 
@@ -25,13 +25,13 @@ const meta: Meta<typeof FileItem> = {
   render: (args, { loaded: { content } }) => {
     return <FileItem {...args} content={content} />;
   },
-};
+} satisfies Meta<typeof FileItem>;
 
 export default meta;
 
-type Story = StoryObj<typeof FileItem>;
+type Story = StoryObj<typeof meta>;
 
-export const Image: Story = {
+export const Image = {
   loaders: [
     async () => ({
       content: await fetch('https://picsum.photos/100').then((r) => r.blob()),
@@ -58,9 +58,9 @@ export const Image: Story = {
       creator: MOCK_MEMBER,
     }),
   },
-};
+} satisfies Story;
 
-export const BigContainedImage: Story = {
+export const BigContainedImage = {
   loaders: [
     async () => ({
       content: await fetch('https://picsum.photos/1000').then((r) => r.blob()),
@@ -90,9 +90,9 @@ export const BigContainedImage: Story = {
       creator: MOCK_MEMBER,
     }),
   },
-};
+} satisfies Story;
 
-export const SmallContainedImage: Story = {
+export const SmallContainedImage = {
   loaders: [
     async () => ({
       content: await fetch('https://picsum.photos/100').then((r) => r.blob()),
@@ -122,9 +122,9 @@ export const SmallContainedImage: Story = {
       creator: MOCK_MEMBER,
     }),
   },
-};
+} satisfies Story;
 
-export const ImageSVG: Story = {
+export const ImageSVG = {
   loaders: [
     async () => ({
       content: await fetch(
@@ -153,9 +153,9 @@ export const ImageSVG: Story = {
       creator: MOCK_MEMBER,
     }),
   },
-};
+} satisfies Story;
 
-export const ImageWebP: Story = {
+export const ImageWebP = {
   loaders: [
     async () => ({
       content: await fetch(
@@ -184,9 +184,9 @@ export const ImageWebP: Story = {
       creator: MOCK_MEMBER,
     }),
   },
-};
+} satisfies Story;
 
-export const WAVAudio: Story = {
+export const WAVAudio = {
   loaders: [
     async () => ({
       content: await fetch(
@@ -214,4 +214,4 @@ export const WAVAudio: Story = {
       creator: MOCK_MEMBER,
     }),
   },
-};
+} satisfies Story;

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { ItemType, MaxWidth, MimeTypes } from '@graasp/sdk';
-import { DEFAULT_LANG } from '@graasp/translations';
+import {
+  ItemType,
+  LocalFileItemFactory,
+  MaxWidth,
+  MimeTypes,
+} from '@graasp/sdk';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
 import { TABLE_CATEGORIES } from '../utils/storybook';
@@ -34,7 +38,7 @@ export const Image: Story = {
     }),
   ],
   args: {
-    item: {
+    item: LocalFileItemFactory({
       id: 'my-id',
       name: 'my item name',
       extra: {
@@ -51,11 +55,8 @@ export const Image: Story = {
       description: 'my image description',
       path: 'item-path',
       settings: {},
-      lang: DEFAULT_LANG,
       creator: MOCK_MEMBER,
-      createdAt: '2023-09-06T11:50:32.894Z',
-      updatedAt: '2023-09-06T11:50:32.894Z',
-    },
+    }),
   },
 };
 
@@ -66,7 +67,7 @@ export const BigContainedImage: Story = {
     }),
   ],
   args: {
-    item: {
+    item: LocalFileItemFactory({
       id: 'my-id',
       name: 'my item name',
       extra: {
@@ -86,11 +87,8 @@ export const BigContainedImage: Story = {
       settings: {
         maxWidth: MaxWidth.Small,
       },
-      lang: DEFAULT_LANG,
       creator: MOCK_MEMBER,
-      createdAt: '2023-09-06T11:50:32.894Z',
-      updatedAt: '2023-09-06T11:50:32.894Z',
-    },
+    }),
   },
 };
 
@@ -101,7 +99,7 @@ export const SmallContainedImage: Story = {
     }),
   ],
   args: {
-    item: {
+    item: LocalFileItemFactory({
       id: 'my-id',
       name: 'my item name',
       extra: {
@@ -121,11 +119,8 @@ export const SmallContainedImage: Story = {
       settings: {
         maxWidth: MaxWidth.Large,
       },
-      lang: DEFAULT_LANG,
       creator: MOCK_MEMBER,
-      createdAt: '2023-09-06T11:50:32.894Z',
-      updatedAt: '2023-09-06T11:50:32.894Z',
-    },
+    }),
   },
 };
 
@@ -138,7 +133,7 @@ export const ImageSVG: Story = {
     }),
   ],
   args: {
-    item: {
+    item: LocalFileItemFactory({
       id: 'my-id',
       name: 'my item name',
       extra: {
@@ -155,11 +150,8 @@ export const ImageSVG: Story = {
       description: 'my svg description',
       path: 'item-path',
       settings: {},
-      lang: DEFAULT_LANG,
       creator: MOCK_MEMBER,
-      createdAt: '2023-09-06T11:50:32.894Z',
-      updatedAt: '2023-09-06T11:50:32.894Z',
-    },
+    }),
   },
 };
 
@@ -172,7 +164,7 @@ export const ImageWebP: Story = {
     }),
   ],
   args: {
-    item: {
+    item: LocalFileItemFactory({
       id: 'my-id',
       name: 'my item name',
       extra: {
@@ -189,11 +181,8 @@ export const ImageWebP: Story = {
       description: 'my webp description',
       path: 'item-path',
       settings: {},
-      lang: DEFAULT_LANG,
       creator: MOCK_MEMBER,
-      createdAt: '2023-09-06T11:50:32.894Z',
-      updatedAt: '2023-09-06T11:50:32.894Z',
-    },
+    }),
   },
 };
 
@@ -206,7 +195,7 @@ export const WAVAudio: Story = {
     }),
   ],
   args: {
-    item: {
+    item: LocalFileItemFactory({
       id: 'my-id',
       name: 'my item name',
       extra: {
@@ -222,10 +211,7 @@ export const WAVAudio: Story = {
       description: 'my audio description',
       path: 'item-path',
       settings: {},
-      lang: DEFAULT_LANG,
       creator: MOCK_MEMBER,
-      createdAt: '2023-09-06T11:50:32.894Z',
-      updatedAt: '2023-09-06T11:50:32.894Z',
-    },
+    }),
   },
 };

--- a/src/items/LinkItem.stories.tsx
+++ b/src/items/LinkItem.stories.tsx
@@ -2,17 +2,13 @@ import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
 import { userEvent, within } from '@storybook/testing-library';
 
-import {
-  EmbeddedLinkItemFactory,
-  EmbeddedLinkItemType,
-  ItemType,
-} from '@graasp/sdk';
+import { EmbeddedLinkItemFactory, ItemType } from '@graasp/sdk';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import LinkItem from './LinkItem';
 
-const item: EmbeddedLinkItemType = EmbeddedLinkItemFactory({
+const item = EmbeddedLinkItemFactory({
   id: 'item-id',
   name: 'item-name',
   type: ItemType.LINK,
@@ -50,7 +46,7 @@ const itemWithHTMLDescription = EmbeddedLinkItemFactory({
     '<p class="ql-align-center">I am centered</p><p>I am left aligned</p><p class="ql-align-right">I am right aligned</p><p class="ql-align-right"><span class="ql-emojiblot" data-name="smiling_imp">﻿<span contenteditable="false"><span class="ap ap-smiling_imp">😈</span></span>﻿</span></p><p class="ql-align-right">I <span style="background-color: rgb(204, 224, 245);">have</span> a <span style="background-color: rgb(194, 133, 255);">background</span></p><p class="ql-align-center"><a href="https://www.google.com" rel="noopener noreferrer" target="_blank">Test link</a></p><p><s>Hey !</s></p><p><strong class="ql-font-serif"><s>Wow</s></strong></p><p><br></p><pre class="ql-syntax" spellcheck="false">Some code too !\n</pre>',
 });
 
-const meta: Meta<typeof LinkItem> = {
+const meta = {
   title: 'Items/LinkItem',
   component: LinkItem,
 
@@ -61,12 +57,12 @@ const meta: Meta<typeof LinkItem> = {
       },
     },
   },
-};
+} satisfies Meta<typeof LinkItem>;
 export default meta;
 
-type Story = StoryObj<typeof LinkItem>;
+type Story = StoryObj<typeof meta>;
 
-export const Iframe: Story = {
+export const Iframe = {
   args: {
     item,
     isResizable: true,
@@ -82,7 +78,7 @@ export const Iframe: Story = {
     }
     expect(canvas.getByTitle(args.item.name)).toBeInTheDocument();
   },
-};
+} satisfies Story;
 
 export const LinkButton: Story = {
   args: {

--- a/src/items/LinkItem.stories.tsx
+++ b/src/items/LinkItem.stories.tsx
@@ -2,14 +2,17 @@ import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
 import { userEvent, within } from '@storybook/testing-library';
 
-import { EmbeddedLinkItemType, ItemType } from '@graasp/sdk';
-import { DEFAULT_LANG } from '@graasp/translations';
+import {
+  EmbeddedLinkItemFactory,
+  EmbeddedLinkItemType,
+  ItemType,
+} from '@graasp/sdk';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
 import { TABLE_CATEGORIES } from '../utils/storybook';
 import LinkItem from './LinkItem';
 
-const item: EmbeddedLinkItemType = {
+const item: EmbeddedLinkItemType = EmbeddedLinkItemFactory({
   id: 'item-id',
   name: 'item-name',
   type: ItemType.LINK,
@@ -23,14 +26,10 @@ const item: EmbeddedLinkItemType = {
     },
   },
   settings: {},
-  lang: DEFAULT_LANG,
-  creator: MOCK_MEMBER,
-  createdAt: '2023-09-06T11:50:32.894Z',
-  updatedAt: '2023-09-06T11:50:32.894Z',
   description: 'my link description',
-};
+});
 
-const itemWithHTMLDescription: EmbeddedLinkItemType = {
+const itemWithHTMLDescription = EmbeddedLinkItemFactory({
   id: 'item-id',
   name: 'item-name',
   type: ItemType.LINK,
@@ -44,13 +43,12 @@ const itemWithHTMLDescription: EmbeddedLinkItemType = {
     },
   },
   settings: {},
-  lang: DEFAULT_LANG,
   creator: MOCK_MEMBER,
   createdAt: '2023-09-06T11:50:32.894Z',
   updatedAt: '2023-09-06T11:50:32.894Z',
   description:
     '<p class="ql-align-center">I am centered</p><p>I am left aligned</p><p class="ql-align-right">I am right aligned</p><p class="ql-align-right"><span class="ql-emojiblot" data-name="smiling_imp">﻿<span contenteditable="false"><span class="ap ap-smiling_imp">😈</span></span>﻿</span></p><p class="ql-align-right">I <span style="background-color: rgb(204, 224, 245);">have</span> a <span style="background-color: rgb(194, 133, 255);">background</span></p><p class="ql-align-center"><a href="https://www.google.com" rel="noopener noreferrer" target="_blank">Test link</a></p><p><s>Hey !</s></p><p><strong class="ql-font-serif"><s>Wow</s></strong></p><p><br></p><pre class="ql-syntax" spellcheck="false">Some code too !\n</pre>',
-};
+});
 
 const meta: Meta<typeof LinkItem> = {
   title: 'Items/LinkItem',

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,8 @@ export type ColorVariants =
 export type IconSizeVariant = 'small' | 'medium' | 'large';
 
 export enum ActionButton {
-  ICON_BUTTON = 'icon',
+  ICON = 'icon',
+  ICON_BUTTON = 'iconButton',
   MENU_ITEM = 'menuItem',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3371,15 +3371,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/translations@npm:1.23.0":
-  version: 1.23.0
-  resolution: "@graasp/translations@npm:1.23.0"
-  dependencies:
-    i18next: "npm:23.7.16"
-  checksum: dc0d605b520a28deb1ad3054323dc4b71f709b79adf5924552c602f3c3ed2fa7c3c8538a3015c86c8db05867159df4b2f6ad18583766b2b97c8dd850952d29e2
-  languageName: node
-  linkType: hard
-
 "@graasp/ui@workspace:.":
   version: 0.0.0-use.local
   resolution: "@graasp/ui@workspace:."
@@ -3393,7 +3384,6 @@ __metadata:
     "@emotion/react": "npm:11.11.3"
     "@emotion/styled": "npm:11.11.0"
     "@graasp/sdk": "npm:3.8.3"
-    "@graasp/translations": "npm:1.23.0"
     "@mui/icons-material": "npm:5.15.8"
     "@mui/lab": "npm:5.0.0-alpha.157"
     "@mui/material": "npm:5.15.8"
@@ -12492,15 +12482,6 @@ __metadata:
   bin:
     husky: bin.mjs
   checksum: c303f1862e2b63873605df55a2b08303155e35c799585d7dd677628f62d716e7304bd984fc7d00ec44e740caac07d51720d1a0abb0a23a70a38859d89eb8e72d
-  languageName: node
-  linkType: hard
-
-"i18next@npm:23.7.16":
-  version: 23.7.16
-  resolution: "i18next@npm:23.7.16"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.2"
-  checksum: 77e74c07a73316f6fb6678a5a3e8ce58a6e66be457dd1ccd23941e9fc57ad8e1da55193fa6328c70b86073337b776cd267f3c13c6309f548b3116f27a1e41787
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR refactors the icon buttons:
- factor out a generic item menu component
- adds item menu variant to some buttons
- add the ICON variant, that returns only the corresponding icon without IconButton