### PR TITLE
fix: wrap component inside Box in withCaption to solve image height

### DIFF
--- a/src/items/withCaption.tsx
+++ b/src/items/withCaption.tsx
@@ -1,6 +1,6 @@
 import TextDisplay from '@/TextDisplay/TextDisplay';
 
-import { Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 
 import { DescriptionPlacement, DescriptionPlacementType } from '@graasp/sdk';
 
@@ -28,7 +28,8 @@ function withCaption<T extends WithCaptionItem>({ item }: WithCaptionProps<T>) {
           : 'column';
       return (
         <Stack direction={direction}>
-          {component}
+          {/* The box prevent the image to take full available space due to the stack */}
+          <Box>{component}</Box>
           <TextDisplay content={item.description ?? DEFAULT_ITEM_DESCRIPTION} />
         </Stack>
       );


### PR DESCRIPTION
- Should solve issue #735.

## Before
![image](https://github.com/graasp/graasp-ui/assets/147397675/4e30aee3-7eb9-453e-bdb7-22fc643e6a69)

## After
![image](https://github.com/graasp/graasp-ui/assets/147397675/946c8f83-0b5a-4e4f-9db6-1ca26ddff8f1)
