### PR TITLE
fix: allow component as card description

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -27,7 +27,7 @@ type CardProps = {
    * creator name
    */
   creator?: string;
-  description?: string;
+  description?: string | JSX.Element;
   height?: string | number;
   /**
    * image link to display as thumbnail


### PR DESCRIPTION
In this PR:
- allow to use a component as the card description