### PR TITLE
fix: decrease cclicence tooltip size

### DIFF
--- a/src/CreativeCommons/CreativeCommons.tsx
+++ b/src/CreativeCommons/CreativeCommons.tsx
@@ -86,10 +86,12 @@ const getLicenseName = (
 
 const CCIcon: FC<CCIconProps> = ({ icon, title, description }) => {
   const tooltip = (
-    <Box>
-      <Typography fontWeight='bold'>{title}</Typography>
-      {description && <Typography variant='body2'>{description}</Typography>}
-    </Box>
+    <Stack direction='column' spacing={1}>
+      <Typography fontWeight='bold' variant='note'>
+        {title}
+      </Typography>
+      {description && <Typography variant='caption'>{description}</Typography>}
+    </Stack>
   );
 
   return (


### PR DESCRIPTION
Before:
<img width="450" alt="Screenshot 2024-04-12 at 11 28 29" src="https://github.com/graasp/graasp-ui/assets/39373170/99666c6b-9ec7-42db-8cee-b3aaffbe1a17">
<img width="450" alt="Screenshot 2024-04-12 at 11 28 34" src="https://github.com/graasp/graasp-ui/assets/39373170/92d89f06-484c-4fbf-8b69-79f9391ff665">

After:
<img width="450" alt="Screenshot 2024-04-12 at 11 28 44" src="https://github.com/graasp/graasp-ui/assets/39373170/ad317c21-b79e-4454-a3ae-4118bc59939d">
<img width="450" alt="Screenshot 2024-04-12 at 11 29 20" src="https://github.com/graasp/graasp-ui/assets/39373170/dfddc11b-6de7-4793-910a-baf49a0fa3df">
