### PR TITLE
fix: update alert title

### DIFF
--- a/src/TextDisplay/withFlavor.tsx
+++ b/src/TextDisplay/withFlavor.tsx
@@ -1,8 +1,27 @@
-import { AlertTitle } from '@mui/material';
+import { AlertTitle, Typography } from '@mui/material';
 import Alert from '@mui/material/Alert';
 
 import { DocumentItemExtraFlavor } from '@graasp/sdk';
 
+const Title = ({
+  title,
+  isAlert = false,
+}: {
+  title?: string;
+  isAlert?: boolean;
+}): JSX.Element | false => {
+  if (!title) {
+    return false;
+  }
+  if (isAlert) {
+    return (
+      <AlertTitle sx={{ fontWeight: 700, fontSize: '1.1rem' }}>
+        {title}
+      </AlertTitle>
+    );
+  }
+  return <Typography variant='h5'>{title}</Typography>;
+};
 type WithFlavorProps = {
   content: JSX.Element | string;
   title?: string;
@@ -16,7 +35,12 @@ export const withFlavor = ({
 }: WithFlavorProps): JSX.Element => {
   if (flavor === DocumentItemExtraFlavor.None) {
     // need to wrap in a fragment because content can be a string which is not a JSX.Element
-    return <>{content}</>;
+    return (
+      <>
+        <Title title={title} />
+        {content}
+      </>
+    );
   }
   return (
     <Alert
@@ -29,7 +53,7 @@ export const withFlavor = ({
         },
       }}
     >
-      {title && <AlertTitle>{title}</AlertTitle>}
+      <Title title={title} isAlert />
       {content}
     </Alert>
   );


### PR DESCRIPTION
Allow to show the title on a DocumentItem more prominently

Before:
<img width="746" alt="Screenshot 2024-04-26 at 17 31 58" src="https://github.com/graasp/graasp-ui/assets/39373170/ae666d43-9b66-4692-ad48-e5a732c9cd34">
<img width="746" alt="Screenshot 2024-04-26 at 17 31 06" src="https://github.com/graasp/graasp-ui/assets/39373170/71218881-f00a-4624-a8bb-8865c35a3410">

After:
<img width="746" alt="Screenshot 2024-04-26 at 17 31 44" src="https://github.com/graasp/graasp-ui/assets/39373170/3d8e3b28-9385-46f1-91ac-8334915a8de5">
<img width="746" alt="Screenshot 2024-04-26 at 17 31 34" src="https://github.com/graasp/graasp-ui/assets/39373170/20eef850-70d0-4c8d-9e7d-8b8f5e3ad70a">
