### PR TITLE
fix: quick fix rerender of column defs

### DIFF
--- a/src/TableComponent/Table.tsx
+++ b/src/TableComponent/Table.tsx
@@ -228,7 +228,7 @@ function GraaspTable<T>({
 
   const buildColumnDefs = useCallback((): ColDef[] => {
     if (!enableDrag) {
-      return columnDefs;
+      return [...columnDefs];
     }
 
     // adds the column drag on the left of the table


### PR DESCRIPTION
https://github.com/graasp/graasp-ui/assets/147397675/1e606fdf-e29e-4906-9caf-70487d59c44d

In this video, the hide/show action is not rerender when the items in the table changed. I fix it quickly because we will change the table soon.