### PR TITLE
fix: allow fullscreen for h5p iframe

### DIFF
--- a/src/items/H5PItem.tsx
+++ b/src/items/H5PItem.tsx
@@ -97,9 +97,13 @@ const H5PItem: FC<H5PItemProps> = ({
       ref={iframeRef}
       id={iframeId}
       src={integrationUrl.href}
-      scrolling={'no'}
-      frameBorder={0}
-      style={{ width: '100%', border: 'none', display: 'block' }}
+      allowFullScreen
+      style={{
+        width: '100%',
+        border: 'none',
+        display: 'block',
+        overflow: 'hidden',
+      }}
     ></iframe>
   );
 

--- a/src/items/H5PItem.tsx
+++ b/src/items/H5PItem.tsx
@@ -89,32 +89,8 @@ const H5PItem: FC<H5PItemProps> = ({
 
     window.addEventListener('message', onResize);
 
-    // handle full screen requested by h5p
-    const setFullHeight = (): void => {
-      if (iframeRef.current === null) {
-        return;
-      }
-      iframeRef.current.height = '100%';
-    };
-
-    /* Standard syntax */
-    window.addEventListener('fullscreenchange', setFullHeight);
-
-    /* Firefox */
-    window.addEventListener('mozfullscreenchange', setFullHeight);
-
-    /* Chrome, Safari and Opera */
-    window.addEventListener('webkitfullscreenchange', setFullHeight);
-
-    /* IE / Edge */
-    window.addEventListener('msfullscreenchange', setFullHeight);
-
     // cleanup on unmount
     return () => {
-      window.removeEventListener('fullscreenchange', setFullHeight);
-      window.removeEventListener('mozfullscreenchange', setFullHeight);
-      window.removeEventListener('webkitfullscreenchange', setFullHeight);
-      window.removeEventListener('msfullscreenchange', setFullHeight);
       window.removeEventListener('message', onResize);
     };
   }, []);
@@ -125,11 +101,11 @@ const H5PItem: FC<H5PItemProps> = ({
       id={iframeId}
       src={integrationUrl.href}
       allowFullScreen
+      scrolling='no'
       style={{
         width: '100%',
         border: 'none',
         display: 'block',
-        overflow: 'hidden',
       }}
     ></iframe>
   );

--- a/src/items/H5PItem.tsx
+++ b/src/items/H5PItem.tsx
@@ -88,8 +88,35 @@ const H5PItem: FC<H5PItemProps> = ({
     };
 
     window.addEventListener('message', onResize);
+
+    // handle full screen requested by h5p
+    const setFullHeight = (): void => {
+      if (iframeRef.current === null) {
+        return;
+      }
+      iframeRef.current.height = '100%';
+    };
+
+    /* Standard syntax */
+    window.addEventListener('fullscreenchange', setFullHeight);
+
+    /* Firefox */
+    window.addEventListener('mozfullscreenchange', setFullHeight);
+
+    /* Chrome, Safari and Opera */
+    window.addEventListener('webkitfullscreenchange', setFullHeight);
+
+    /* IE / Edge */
+    window.addEventListener('msfullscreenchange', setFullHeight);
+
     // cleanup on unmount
-    return () => window.removeEventListener('message', onResize);
+    return () => {
+      window.removeEventListener('fullscreenchange', setFullHeight);
+      window.removeEventListener('mozfullscreenchange', setFullHeight);
+      window.removeEventListener('webkitfullscreenchange', setFullHeight);
+      window.removeEventListener('msfullscreenchange', setFullHeight);
+      window.removeEventListener('message', onResize);
+    };
   }, []);
 
   let iframeH5Pitem = (


### PR DESCRIPTION
Some h5p provide fullscreen feature. Before the fix it resized once and stays like this, it's impossible to revert.


https://github.com/graasp/graasp-ui/assets/11229627/eda5ac7f-83ea-48c9-afc5-05a0e5188a34



I added the `allowFullscreen` prop for the iframe.
It does not work perfectly, one click over three resize weirdly. 

Without this change, the fullscreen does not work at all, so I guess it's okay as compromise.
I quickly tried to set `height=100%` on fullscreen event, but it didn't work.

https://github.com/graasp/graasp-ui/assets/11229627/09f9ebba-74be-4759-80d8-acf84dd31ff5

