### PR TITLE
fix: remove max-height

### DIFF
--- a/src/items/withResizing.tsx
+++ b/src/items/withResizing.tsx
@@ -30,7 +30,7 @@ export const AppIFrame = styled('iframe')<{
   isResizable?: boolean;
 }>(({ isResizable }) => ({
   ...iframeCommonStyles,
-  maxHeight: !isResizable ? ITEM_MAX_HEIGHT : undefined,
+  // maxHeight: !isResizable ? ITEM_MAX_HEIGHT : undefined,
   /**
    * IMPORTANT to not override the height when using dynamic sizing
    * The present styles are applied with higher specificity, so the dynamic height

--- a/src/items/withResizing.tsx
+++ b/src/items/withResizing.tsx
@@ -30,7 +30,6 @@ export const AppIFrame = styled('iframe')<{
   isResizable?: boolean;
 }>(({ isResizable }) => ({
   ...iframeCommonStyles,
-  // maxHeight: !isResizable ? ITEM_MAX_HEIGHT : undefined,
   /**
    * IMPORTANT to not override the height when using dynamic sizing
    * The present styles are applied with higher specificity, so the dynamic height


### PR DESCRIPTION
In this PR I remove the maxHeight of 70vh on the app iframe.

This code has been used in builder and player and deployed to test the effect. It works as expected for automatic height apps. 