### PR TITLE
feat: add draggable elements, to replace table

### DIFF
--- a/src/Card/Card.stories.tsx
+++ b/src/Card/Card.stories.tsx
@@ -1,8 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import AcUnitIcon from '@mui/icons-material/AcUnit';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import GrainIcon from '@mui/icons-material/Grain';
+import { Box, Stack } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
+
+import { BrowserRouter } from 'react-router-dom';
 
 import ItemBadges from '../ItemBadges/ItemBadges';
 import { TABLE_CATEGORIES } from '../utils/storybook';
@@ -27,11 +30,52 @@ type Story = StoryObj<typeof meta>;
 export const Example: Story = {
   args: {
     name: 'my card title',
-    description:
-      'my card description might be really long that is why we cut it after some lines of text to allow some space for more data',
-    image: 'https://picsum.photos/200/100',
+    alt: 'my card title',
+    content: (
+      <span>
+        'my card description might be really long that is why we cut it after
+        some lines of text to allow some space for more data'
+      </span>
+    ),
+    thumbnail: 'https://picsum.photos/200/100',
     creator: 'graasp',
-    Actions: (
+    footer: (
+      <Stack
+        width='100%'
+        alignItems='end'
+        direction='row'
+        justifyContent='space-between'
+      >
+        <Box>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+        </Box>
+        <IconButton>
+          <GrainIcon />
+        </IconButton>
+      </Stack>
+    ),
+  },
+} satisfies Story;
+
+export const Dense: Story = {
+  args: {
+    dense: true,
+    name: 'my card title',
+    content: 'folder',
+    fullWidth: true,
+    elevation: false,
+    creator: 'graasp',
+    alt: 'graasp',
+    to: 'graasp',
+    footer: (
       <>
         <IconButton>
           <AcUnitIcon />
@@ -44,112 +88,128 @@ export const Example: Story = {
         </IconButton>
       </>
     ),
-    ItemMenu: (
+    menu: (
       <IconButton>
-        <MoreVertIcon />
+        <AcUnitIcon />
       </IconButton>
     ),
   },
+  decorators: [
+    (story) => {
+      return <BrowserRouter>{story()}</BrowserRouter>;
+    },
+  ],
 } satisfies Story;
 
 export const FullWidth = {
   args: {
     fullWidth: true,
-    name: 'my card title',
-    description:
-      'my card description might be really long that is why we cut it after some lines of text to allow some space for more data',
-    image: 'https://picsum.photos/200/100',
-    creator: 'graasp',
-    Actions: (
-      <>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-      </>
+    content: (
+      <span>
+        'my card description might be really long that is why we cut it after
+        some lines of text to allow some space for more data'
+      </span>
     ),
-    ItemMenu: (
-      <IconButton>
-        <MoreVertIcon />
-      </IconButton>
+    name: 'my card title',
+    alt: 'my card title',
+    thumbnail: 'https://picsum.photos/200/100',
+    creator: 'graasp',
+
+    footer: (
+      <Stack
+        width='100%'
+        alignItems='center'
+        direction='row'
+        justifyContent='space-between'
+      >
+        <ItemBadges isHidden isPublic isPublished isPinned />
+        <Box>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+        </Box>
+      </Stack>
     ),
   },
 } satisfies Story;
 
-export const Badges: Story = {
-  args: {
-    name: 'my card title',
-    description:
-      'my card description might be really long that is why we cut it after some lines of text to allow some space for more data',
-    image: 'https://picsum.photos/200/100',
-    creator: 'graasp',
-    Actions: (
-      <>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-      </>
-    ),
-    Badges: <ItemBadges isHidden isPublic isPublished isPinned />,
-    ItemMenu: (
-      <IconButton>
-        <MoreVertIcon />
-      </IconButton>
-    ),
-  },
-};
-
 export const NoActions: Story = {
   args: {
     name: 'my card title',
-    description:
-      'my card description might be really long that is why we cut it after some lines of text to allow some space for more data and we can see the overflow also here it i going to be visible ?',
-    image: 'https://picsum.photos/100/100',
+    thumbnail: 'https://picsum.photos/100/100',
     creator: 'graasp',
-    ItemMenu: (
-      <IconButton>
-        <MoreVertIcon />
-      </IconButton>
+    alt: 'graasp',
+    content: (
+      <span>
+        'my card description might be really long that is why we cut it after
+        some lines of text to allow some space for more data'
+      </span>
     ),
   },
 };
 
 export const TallCard: Story = {
   args: {
+    content: (
+      <span>
+        'my card description might be really long that is why we cut it after
+        some lines of text to allow some space for more data'
+      </span>
+    ),
     name: 'my card title',
-    description:
-      'my card description might be really long that is why we cut it after some lines of text to allow some space for more data',
-    image: 'https://picsum.photos/200/500',
+    alt: 'my card title',
+    thumbnail: 'https://picsum.photos/200/500',
     creator: 'graasp',
     height: 300,
-    Actions: (
-      <>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-        <IconButton>
-          <AcUnitIcon />
-        </IconButton>
-      </>
-    ),
-    ItemMenu: (
-      <IconButton>
-        <MoreVertIcon />
-      </IconButton>
+    footer: (
+      <Stack
+        width='100%'
+        alignItems='center'
+        direction='row'
+        justifyContent='space-between'
+      >
+        <ItemBadges isHidden isPublic isPublished isPinned />
+        <Box>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+          <IconButton>
+            <AcUnitIcon />
+          </IconButton>
+        </Box>
+      </Stack>
     ),
   },
 };
+
+export const DenseMobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile2',
+    },
+  },
+  args: {
+    dense: true,
+    name: 'my card title',
+    content: 'my content',
+    fullWidth: true,
+    elevation: false,
+    creator: 'graasp',
+    alt: 'graasp',
+    footer: 'myfooter',
+  },
+  decorators: [
+    (story) => {
+      return <BrowserRouter>{story()}</BrowserRouter>;
+    },
+  ],
+} satisfies Story;

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -1,92 +1,196 @@
-import { Box, Stack, SxProps, styled } from '@mui/material';
-import Card from '@mui/material/Card';
+import { Stack, SxProps, styled } from '@mui/material';
+import MuiCard from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import Typography from '@mui/material/Typography';
+import Grid2 from '@mui/material/Unstable_Grid2';
 
-import { FC, ReactElement } from 'react';
+import { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 
-import CardHeader from './CardHeader';
+import type { DraggableAndDroppableProps } from '../draggable/types';
+import CardThumbnail, { CardThumbnailProps } from './CardThumbnail';
 
 const DEFAULT_CARD_HEIGHT = 130;
 
-const StyledImage = styled('img')({
-  width: '100%',
-  height: '100%',
-  objectFit: 'cover',
-});
-
-const StyledCard = styled(Card, {
-  shouldForwardProp: (prop) => prop !== 'fullWidth',
-})<{ fullWidth: boolean }>(({ theme, fullWidth }) => ({
-  borderRadius: theme.spacing(1),
-  boxShadow: theme.shadows[2],
-  width: fullWidth ? '100%' : 'max-content',
-  maxWidth: '100%',
-}));
+const StyledCard = styled(MuiCard, {
+  shouldForwardProp: (prop) => prop !== 'elevation' && prop !== 'fullWidth',
+})<{ isOver: boolean; fullWidth?: boolean; elevation?: boolean }>(
+  ({ theme, elevation, fullWidth, isOver }) => ({
+    borderRadius: theme.spacing(1),
+    boxShadow: elevation ? theme.shadows[2] : '0px 2px 2px #eeeeee',
+    width: fullWidth ? '100%' : 'max-content',
+    maxWidth: '100%',
+    border: isOver ? '2px solid black' : 'none',
+  }),
+);
 
 type CardProps = {
-  name: string;
-  /**
-   * actions displayed at the bottom of the card
-   */
-  Actions?: ReactElement;
-  Badges?: ReactElement;
-  cardId?: string;
+  name: string | JSX.Element;
+  alt: string;
+  id?: string;
   /**
    * creator name
    */
   creator?: string;
-  description?: string | JSX.Element;
-  height?: string | number;
+  height?: number;
   /**
    * image link to display as thumbnail
    */
-  image?: string;
-  ItemMenu?: ReactElement;
-  NameWrapper?: ({ children }: { children: JSX.Element }) => JSX.Element;
+  thumbnail?: string;
+  footer?: string | ReactElement;
   sx?: SxProps;
   /**
    * Whether the card should expand to take all available space
    */
   fullWidth?: boolean;
-  /**
-   * thumbnail component, override image
-   */
-  Thumbnail?: ReactElement;
-};
 
-const Item: FC<CardProps> = ({
-  Actions,
-  Badges,
-  cardId,
-  creator,
-  description,
-  height = DEFAULT_CARD_HEIGHT,
-  image,
-  ItemMenu,
-  name,
-  NameWrapper,
-  sx,
-  Thumbnail,
-  fullWidth = false,
-}) => {
-  const ThumbnailWrapper = styled(Box)({
-    // use a square box to display the image
-    width: height,
-    height,
-    maxWidth: '50%',
-    // don't shrink the image on flex
-    flexShrink: 0,
-  });
+  dense?: boolean;
+  elevation?: boolean;
+  menu?: JSX.Element;
+  content?: string | JSX.Element | JSX.Element[];
 
-  const renderImage = (): ReactElement => {
-    return Thumbnail || <StyledImage src={image} alt={name} />;
-  };
+  to?: string;
+  type?: CardThumbnailProps['type'];
+} & Partial<DraggableAndDroppableProps>;
+
+const Wrapper = ({
+  children,
+  to,
+}: {
+  children?: string | JSX.Element | JSX.Element[];
+  to?: string;
+}): JSX.Element => {
+  if (!to) {
+    return <>{children}</>;
+  }
 
   return (
-    <StyledCard id={cardId} sx={sx} fullWidth={fullWidth}>
+    <Link to={to} style={{ textDecoration: 'none', color: 'unset' }}>
+      {children}
+    </Link>
+  );
+};
+
+const Card = ({
+  footer,
+  id,
+  creator,
+  height: heightProp,
+  name,
+  sx,
+  dense,
+  thumbnail,
+  menu,
+  fullWidth = false,
+  elevation = true,
+  content,
+  alt,
+  to,
+  type,
+  isOver = false,
+  isDragging = false,
+}: CardProps): JSX.Element => {
+  let height = heightProp;
+  if (!height) {
+    height = dense ? 60 : DEFAULT_CARD_HEIGHT;
+  }
+
+  if (dense) {
+    return (
+      <StyledCard
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        elevation={elevation && !isDragging}
+        id={id}
+        sx={sx}
+        fullWidth={fullWidth}
+        isOver={isOver}
+      >
+        <Stack
+          sx={{ height, boxSizing: 'border-box' }}
+          direction='row'
+          gap={1}
+          alignItems='center'
+          mr={1}
+        >
+          <CardThumbnail
+            width={height}
+            minHeight={height}
+            thumbnail={thumbnail}
+            alt={alt}
+            type={type}
+          />
+          <Grid2
+            container
+            // necessary to respect flex layout, otherwise it does not compress
+            minWidth={0}
+            width='100%'
+            sx={{ mt: 0 }}
+            // ensure that if there is no description the element still goes edge to edge
+            boxSizing='border-box'
+            marginTop={1}
+            justifyContent='space-between'
+            alignItems='center'
+          >
+            <Grid2
+              xs={9}
+              sm={5}
+              md={5}
+              justifyContent='space-between'
+              // align to the top so the button does not move when there is no creator
+              alignItems='start'
+              boxSizing='border-box'
+            >
+              <Wrapper to={to}>
+                <Stack minWidth={0}>
+                  <Typography noWrap variant={dense ? 'h5' : 'h3'}>
+                    {name}
+                  </Typography>
+                  {creator && (
+                    <Typography
+                      noWrap
+                      variant={dense ? 'caption' : 'body1'}
+                      color='text.secondary'
+                    >
+                      {creator}
+                    </Typography>
+                  )}
+                </Stack>
+              </Wrapper>
+            </Grid2>
+            <Grid2 sm={4} xs={0} md={5} display={{ xs: 'none', sm: 'block' }}>
+              <Wrapper to={to}>{content}</Wrapper>
+            </Grid2>
+            <Grid2 xs={3} sm={3} md={2} justifyContent='flex-end'>
+              <CardActions sx={{ p: 0, justifyContent: 'flex-end' }}>
+                <Stack
+                  width='100%'
+                  alignItems='end'
+                  direction='row'
+                  justifyContent='flex-end'
+                  alignContent='center'
+                  display={{ xs: 'none', sm: 'block' }}
+                >
+                  {footer}
+                </Stack>
+                {menu}
+              </CardActions>
+            </Grid2>
+          </Grid2>
+        </Stack>
+      </StyledCard>
+    );
+  }
+
+  return (
+    <StyledCard isOver={isOver} id={id} sx={sx} fullWidth={fullWidth}>
       <Stack sx={{ height, boxSizing: 'border-box' }} direction='row' gap={2}>
-        <ThumbnailWrapper>{renderImage()}</ThumbnailWrapper>
+        <CardThumbnail
+          width={height}
+          minHeight={height}
+          thumbnail={thumbnail}
+          alt={alt}
+        />
 
         <Stack
           direction='column'
@@ -97,12 +201,31 @@ const Item: FC<CardProps> = ({
           boxSizing='border-box'
           marginTop={1}
         >
-          <CardHeader
-            name={name}
-            creator={creator}
-            ItemMenu={ItemMenu}
-            NameWrapper={NameWrapper}
-          />
+          <Stack
+            direction='row'
+            justifyContent='space-between'
+            // align to the top so the button does not move when there is no creator
+            alignItems='start'
+            boxSizing='border-box'
+          >
+            <Wrapper to={to}>
+              <Stack minWidth={0} direction='column'>
+                <Typography noWrap variant={dense ? 'h5' : 'h3'}>
+                  {name}
+                </Typography>
+                {creator && (
+                  <Typography
+                    noWrap
+                    variant={dense ? 'caption' : 'body1'}
+                    color='text.secondary'
+                  >
+                    {creator}
+                  </Typography>
+                )}
+              </Stack>
+            </Wrapper>
+            {menu}
+          </Stack>
           <Typography
             justifySelf='start'
             // necessary for the `position: absolute` on the :before to work
@@ -132,27 +255,13 @@ const Item: FC<CardProps> = ({
               },
             }}
           >
-            {description}
+            {content}
           </Typography>
-          {(Actions || Badges) && (
-            <CardActions sx={{ pt: 0, pl: 0 }}>
-              <Stack
-                width='100%'
-                alignItems='end'
-                direction='row'
-                justifyContent='space-between'
-              >
-                {Badges || <span />}
-                <Box margin={(theme) => `-${theme.spacing(1)}`}>
-                  {Actions || <span />}
-                </Box>
-              </Stack>
-            </CardActions>
-          )}
+          {footer}
         </Stack>
       </Stack>
     </StyledCard>
   );
 };
 
-export default Item;
+export default Card;

--- a/src/Card/CardHeader.tsx
+++ b/src/Card/CardHeader.tsx
@@ -8,12 +8,14 @@ type CardHeaderProps = {
   creator?: string;
   ItemMenu?: ReactElement;
   NameWrapper?: ({ children }: { children: JSX.Element }) => JSX.Element;
+  dense?: boolean;
 };
 
 const CustomCardHeader: FC<CardHeaderProps> = ({
   name,
   creator,
   ItemMenu,
+  dense,
   NameWrapper = ({ children }: { children: ReactElement }) => children,
 }) => {
   return (
@@ -26,12 +28,16 @@ const CustomCardHeader: FC<CardHeaderProps> = ({
     >
       <Stack minWidth={0} direction='column'>
         <NameWrapper>
-          <Typography noWrap variant='h3'>
+          <Typography noWrap variant={dense ? 'h5' : 'h3'}>
             {name}
           </Typography>
         </NameWrapper>
         {creator && (
-          <Typography noWrap variant='body1' color='text.secondary'>
+          <Typography
+            noWrap
+            variant={dense ? 'caption' : 'body1'}
+            color='text.secondary'
+          >
             {creator}
           </Typography>
         )}

--- a/src/Card/CardThumbnail.tsx
+++ b/src/Card/CardThumbnail.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material';
+
+import { DiscriminatedItem, ItemType } from '@graasp/sdk';
+
+import { ItemIcon, Thumbnail } from '..';
+
+export type CardThumbnailProps = {
+  thumbnail?: string;
+  alt: string;
+  width?: number;
+  minHeight: number;
+  type?: DiscriminatedItem['type'];
+};
+const CardThumbnail = ({
+  thumbnail,
+  alt,
+  width,
+  minHeight,
+  type = ItemType.FOLDER,
+}: CardThumbnailProps): JSX.Element => {
+  if (thumbnail) {
+    return (
+      <Thumbnail url={thumbnail} alt={alt} maxHeight='100%' maxWidth={width} />
+    );
+  }
+
+  return (
+    <Box
+      display='flex'
+      alignItems='center'
+      justifyContent='center'
+      bgcolor='#E4DFFF'
+      width={width}
+      height='100%'
+      flexShrink={0}
+      minHeight={minHeight}
+      minWidth={0}
+    >
+      <ItemIcon type={type} alt={alt} />
+    </Box>
+  );
+};
+
+export default CardThumbnail;

--- a/src/Card/Cards.stories.tsx
+++ b/src/Card/Cards.stories.tsx
@@ -2,9 +2,14 @@ import { Meta, StoryObj, composeStories } from '@storybook/react';
 
 import Grid2 from '@mui/material/Unstable_Grid2';
 
+import { PackedFolderItemFactory } from '@graasp/sdk';
+
+import { ItemBadges } from '..';
 import * as CardStories from './Card.stories';
 
-const { FullWidth } = composeStories(CardStories);
+const { FullWidth, Dense } = composeStories(CardStories);
+
+const data = Array.from({ length: 12 }, () => PackedFolderItemFactory());
 
 const meta = {
   title: 'Common/Cards',
@@ -30,6 +35,81 @@ export const GridOfCards = {
         {Array.from(Array(12)).map((_, i) => (
           <Grid2 key={`cardno${i}`} xs={xs}>
             <FullWidth />
+          </Grid2>
+        ))}
+      </Grid2>
+    );
+  },
+} satisfies Story;
+
+export const GridOfDenseCards = {
+  args: {
+    xs: 12,
+  },
+  render: ({ xs }) => {
+    return (
+      <Grid2 container spacing={2}>
+        {data.map((item) => (
+          <Grid2 key={item.id} xs={xs}>
+            <Dense
+              creator={item.creator?.name}
+              name={item.name}
+              content={
+                <Grid2 container columns={{ xs: 12 }}>
+                  <Grid2 xs={12} md={6}>
+                    {item.type}
+                  </Grid2>
+                  <Grid2 xs={12} md={6}>
+                    {item.createdAt}
+                  </Grid2>
+                </Grid2>
+              }
+              fullWidth
+              footer={
+                <ItemBadges
+                  isCollapsible={item.settings.isCollapsible}
+                  isHidden={Boolean(item.hidden)}
+                />
+              }
+            />
+          </Grid2>
+        ))}
+      </Grid2>
+    );
+  },
+} satisfies Story;
+
+export const GridOfDenseWithClickCards = {
+  args: {
+    xs: 12,
+  },
+  render: ({ xs }) => {
+    return (
+      <Grid2 container spacing={2}>
+        {data.map((i) => (
+          <Grid2 key={`cardno${i}`} xs={xs}>
+            <Dense
+              creator={i.creator?.name}
+              name={i.name}
+              to={'to'}
+              content={
+                <Grid2 container columns={{ xs: 12 }}>
+                  <Grid2 xs={12} md={6}>
+                    {i.type}
+                  </Grid2>
+                  <Grid2 xs={12} md={6}>
+                    {i.createdAt}
+                  </Grid2>
+                </Grid2>
+              }
+              fullWidth
+              footer={
+                <ItemBadges
+                  isCollapsible={i.settings.isCollapsible}
+                  isHidden={Boolean(i.hidden)}
+                />
+              }
+            />
           </Grid2>
         ))}
       </Grid2>

--- a/src/Card/FolderCard.tsx
+++ b/src/Card/FolderCard.tsx
@@ -10,8 +10,11 @@ import {
 
 import { Link, LinkProps } from 'react-router-dom';
 
-import CardThumbnail from './components/CardThumbnail';
-import { CARD_HEIGHT } from './constants';
+import { ItemType } from '@graasp/sdk';
+
+import CardThumbnail from './CardThumbnail';
+
+export const CARD_HEIGHT = 76;
 
 type Props = {
   id?: string;
@@ -46,7 +49,13 @@ const FolderCard = ({
     >
       <CardActionArea component={Link} to={to} sx={{ height: '100%' }}>
         <Stack direction='row' alignItems='center' height='100%' minWidth={0}>
-          <CardThumbnail thumbnail={thumbnail} alt={name} />
+          <CardThumbnail
+            width={CARD_HEIGHT}
+            minHeight={CARD_HEIGHT}
+            thumbnail={thumbnail}
+            alt={name}
+            type={ItemType.FOLDER}
+          />
           <CardHeader
             sx={{
               // needed to make container not overflow parent

--- a/src/buttons/Button/Button.tsx
+++ b/src/buttons/Button/Button.tsx
@@ -33,6 +33,8 @@ export type GraaspButtonProps = {
   startIcon?: ReactNode;
   type?: ButtonProps['type'];
   variant?: ButtonProps['variant'];
+
+  role?: ButtonProps['role'];
 } & Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target'>;
 
 export const GraaspButton = ({
@@ -51,9 +53,11 @@ export const GraaspButton = ({
   type,
   variant = 'contained',
   href,
+  role,
   ...other
 }: GraaspButtonProps): JSX.Element => (
   <Button
+    role={role}
     autoFocus={autoFocus}
     className={className}
     color={color}

--- a/src/draggable/DraggableElement.tsx
+++ b/src/draggable/DraggableElement.tsx
@@ -1,0 +1,81 @@
+import { Box, BoxProps } from '@mui/material';
+
+import { ConnectableElement, useDrag, useDrop } from 'react-dnd';
+import { NativeTypes } from 'react-dnd-html5-backend';
+
+import { DraggableAndDroppableProps, DroppedFile } from './types';
+
+export type DraggableElementProps<T> = {
+  row: T;
+  onDrop: (draggedRow: T | DroppedFile, targetRow: T) => void;
+  isMovable?: (el: T) => boolean;
+  renderComponent: (
+    el: T | DroppedFile,
+    args: DraggableAndDroppableProps,
+  ) => JSX.Element;
+  allowFiles?: boolean;
+  canDrop?: (el: T | DroppedFile) => boolean;
+};
+
+const DraggableElement = <T extends object>({
+  row,
+  onDrop,
+  canDrop = () => true,
+  isMovable = () => true,
+  renderComponent,
+  allowFiles = true,
+}: DraggableElementProps<T>): JSX.Element => {
+  const accept = ['row'];
+  if (allowFiles) {
+    accept.push(NativeTypes.FILE);
+  }
+  const [{ isOver }, dropRef] = useDrop(
+    {
+      accept,
+      canDrop,
+      drop: (draggedRow: T | DroppedFile) => {
+        onDrop(draggedRow, row);
+      },
+      collect: (monitor) => ({
+        isOver:
+          monitor.getItem() !== row &&
+          canDrop(monitor.getItem()) &&
+          !!monitor.isOver(),
+      }),
+    },
+    [onDrop],
+  );
+
+  const [{ isDragging }, dragRef] = useDrag({
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+    item: () => row,
+    type: 'row',
+  });
+
+  const attachRef: BoxProps['ref'] = (el: ConnectableElement) => {
+    dragRef(el);
+    dropRef(el);
+  };
+
+  const canMove = isMovable(row);
+  return (
+    <Box
+      ref={canMove ? attachRef : undefined}
+      sx={
+        canMove
+          ? {
+              '&:hover': {
+                cursor: 'grab',
+              },
+            }
+          : undefined
+      }
+    >
+      {renderComponent(row, { isDragging, isOver, isMovable: canMove })}
+    </Box>
+  );
+};
+
+export default DraggableElement;

--- a/src/draggable/DraggingWrapper.stories.tsx
+++ b/src/draggable/DraggingWrapper.stories.tsx
@@ -1,0 +1,202 @@
+import { TABLE_CATEGORIES } from '@/utils/storybook';
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { Box } from '@mui/material';
+
+import { BrowserRouter } from 'react-router-dom';
+
+import { FolderItemFactory, FolderItemType } from '@graasp/sdk';
+
+import { Card, ItemBadges } from '..';
+import DraggingWrapper from './DraggingWrapper';
+
+const makeData = (len: number): FolderItemType[] => {
+  return Array.from({ length: len }, () => FolderItemFactory());
+};
+
+const meta: Meta<typeof DraggingWrapper> = {
+  title: 'Common/Draggable',
+  component: DraggingWrapper,
+  decorators: [
+    (story) => {
+      return <BrowserRouter>{story()}</BrowserRouter>;
+    },
+  ],
+
+  argTypes: {
+    onDropInRow: {
+      action: 'on drop in row',
+
+      table: {
+        category: TABLE_CATEGORIES.EVENTS,
+      },
+    },
+    onDropBetweenRow: {
+      action: 'on drop between rows',
+
+      table: {
+        category: TABLE_CATEGORIES.EVENTS,
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DraggingWrapper>;
+
+export const Default = {
+  args: {
+    rows: makeData(6),
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    renderComponent: (el: FolderItemType, { isDragging, isOver }) => {
+      return (
+        <Card
+          dense
+          alt={el.name}
+          creator={el.creator?.name}
+          name={el.name}
+          content={el.description?.slice(0, 55) ?? ''}
+          fullWidth
+          footer={<ItemBadges isCollapsible isHidden />}
+          to={el.name}
+          isDragging={isDragging}
+          isOver={isOver}
+        />
+      );
+    },
+  },
+} satisfies Story;
+
+export const DisableDragging = {
+  args: {
+    rows: makeData(6),
+    isMovable: () => false,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    renderComponent: (el: FolderItemType) => {
+      return (
+        <Card
+          dense
+          alt={el.name}
+          creator={el.creator?.name}
+          name={el.name}
+          content={el.description ?? ''}
+          fullWidth
+          footer={<ItemBadges isCollapsible isHidden />}
+        />
+      );
+    },
+  },
+} satisfies Story;
+
+export const DynamicCanDrop = {
+  args: {
+    rows: makeData(6),
+    canDrop: (el) => {
+      if (el && 'name' in el) {
+        return (el.name as string).length > 10;
+      }
+      return false;
+    },
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    renderComponent: (el: FolderItemType, { isDragging, isOver }) => {
+      return (
+        <Card
+          sx={{
+            background: isOver ? 'red' : 'none',
+
+            opacity: isDragging ? 0.5 : 1,
+          }}
+          dense
+          alt={el.name}
+          creator={el.creator?.name}
+          name={el.name}
+          content={el.description ?? ''}
+          fullWidth
+          footer={<ItemBadges isCollapsible isHidden />}
+        />
+      );
+    },
+  },
+} satisfies Story;
+
+export const DynamicIsMovable = {
+  args: {
+    rows: makeData(6),
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    isMovable: (el: { name: string }) => {
+      return el.name.length > 20;
+    },
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    renderComponent: (
+      el: FolderItemType,
+      { isDragging, isOver, isMovable },
+    ) => {
+      return (
+        <Card
+          sx={{
+            borderStyle: 'solid',
+            borderWidth: '1px',
+            borderColor: isOver ? 'red' : 'none',
+            opacity: isDragging ? 0.5 : 1,
+            background: isMovable ? 'inherit' : 'lightgrey',
+          }}
+          dense
+          alt={el.name}
+          creator={el.creator?.name}
+          name={el.name}
+          content={el.description ?? ''}
+          fullWidth
+          footer={<ItemBadges isCollapsible isHidden />}
+        />
+      );
+    },
+  },
+} satisfies Story;
+
+export const Columns = {
+  args: {
+    rows: makeData(6),
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    isMovable: (el: { name: string }) => {
+      return el.name.length > 20;
+    },
+    xs: 6,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    renderComponent: (
+      el: FolderItemType,
+      { isDragging, isOver, isMovable },
+    ) => {
+      return (
+        <Box px={1}>
+          <Card
+            sx={{
+              borderStyle: 'solid',
+              borderWidth: '1px',
+              boxSizing: 'border-box',
+              borderColor: isOver ? 'red' : 'none',
+              opacity: isDragging ? 0.5 : 1,
+              background: isMovable ? 'inherit' : 'lightgrey',
+            }}
+            dense
+            alt={el.name}
+            creator={el.creator?.name}
+            name={el.name}
+            content={el.description ?? ''}
+            fullWidth
+            footer={<ItemBadges isCollapsible isHidden />}
+          />
+        </Box>
+      );
+    },
+  },
+} satisfies Story;

--- a/src/draggable/DraggingWrapper.tsx
+++ b/src/draggable/DraggingWrapper.tsx
@@ -1,0 +1,97 @@
+// we could replace dnd with this https://docs.dndkit.com
+import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
+
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+
+import DraggableElement, { DraggableElementProps } from './DraggableElement';
+import InBetween, { InBetweenProps } from './InBetween';
+import { DroppedFile } from './types';
+
+export type DraggingWrapperProps<T> = {
+  renderComponent: DraggableElementProps<T>['renderComponent'];
+
+  rows?: T[];
+
+  /** wrapper id */
+  id?: string;
+  getRowId?: (el: T) => string;
+
+  /** show drag anchor */
+  isMovable?: DraggableElementProps<T>['isMovable'];
+  /** handler on drop in a row */
+  onDropInRow?: DraggableElementProps<T>['onDrop'];
+  /** enable to drag in between rows */
+  enableMoveInBetween?: boolean;
+  /** handler on drop in between rows */
+  onDropBetweenRow?: InBetweenProps<T>['onDrop'];
+
+  allowFiles?: DraggableElementProps<T>['allowFiles'];
+
+  canDrop?: DraggableElementProps<T>['canDrop'];
+
+  /** number of columns */
+  nbColumns?: number;
+};
+
+const DraggingWrapper = <T extends object>({
+  id,
+  rows = [],
+  getRowId,
+  onDropInRow: onDropInRowFn,
+  onDropBetweenRow: onDropBetweenRowFn,
+  renderComponent,
+  isMovable,
+  enableMoveInBetween = true,
+  allowFiles = true,
+  canDrop,
+  nbColumns = 1,
+}: DraggingWrapperProps<T>): JSX.Element => {
+  const onDropInRow = (draggedRow: T | DroppedFile, targetRow: T): void => {
+    onDropInRowFn?.(draggedRow, targetRow);
+  };
+
+  const onDropBetweenRow = (
+    draggedRow: T | DroppedFile,
+    previousRow?: T,
+  ): void => {
+    onDropBetweenRowFn?.(draggedRow, previousRow);
+  };
+
+  return (
+    // we need context={window} to use multiple times in the document
+    // https://github.com/react-dnd/react-dnd/issues/3257#issuecomment-1239254032
+    <DndProvider backend={HTML5Backend} context={window}>
+      <Grid2 container id={id} width='100%'>
+        <Grid2 xs={12}>
+          <InBetween<T>
+            onDrop={onDropBetweenRow}
+            enableMoveInBetween={enableMoveInBetween}
+            renderComponent={renderComponent}
+          />
+        </Grid2>
+        {rows.map((row) => (
+          <Grid2 xs={Math.floor(12 / nbColumns)}>
+            <DraggableElement<T>
+              canDrop={canDrop}
+              allowFiles={allowFiles}
+              isMovable={isMovable}
+              key={getRowId?.(row)}
+              row={row}
+              renderComponent={renderComponent}
+              onDrop={onDropInRow}
+            />
+            <InBetween<T>
+              allowFiles={allowFiles}
+              renderComponent={renderComponent}
+              enableMoveInBetween={enableMoveInBetween}
+              previousRow={row}
+              onDrop={onDropBetweenRow}
+            />
+          </Grid2>
+        ))}
+      </Grid2>
+    </DndProvider>
+  );
+};
+export default DraggingWrapper;

--- a/src/draggable/InBetween.tsx
+++ b/src/draggable/InBetween.tsx
@@ -1,0 +1,73 @@
+// we could replace dnd with this https://docs.dndkit.com
+import { Box } from '@mui/material';
+
+import { useDrop } from 'react-dnd';
+import { NativeTypes } from 'react-dnd-html5-backend';
+
+import type { DraggableAndDroppableProps, DroppedFile } from './types';
+
+export type InBetweenProps<T> = {
+  previousRow?: T;
+  enableMoveInBetween: boolean;
+  onDrop: (draggedRow: T | DroppedFile, previous?: T) => void;
+  renderComponent: (
+    el: T | DroppedFile,
+    args: DraggableAndDroppableProps,
+  ) => JSX.Element;
+  allowFiles?: boolean;
+};
+
+const InBetween = <T extends object>({
+  previousRow,
+  onDrop,
+  enableMoveInBetween,
+  renderComponent,
+  allowFiles = true,
+}: InBetweenProps<T>): JSX.Element => {
+  const accept = ['row'];
+  if (allowFiles) {
+    accept.push(NativeTypes.FILE);
+  }
+  const [{ isOver, data }, drop] = useDrop(
+    () => ({
+      accept,
+      drop: (draggedRow: T | DroppedFile) => {
+        return onDrop(draggedRow, previousRow);
+      },
+      canDrop: () => enableMoveInBetween,
+      collect: (monitor) => ({
+        isOver: !!monitor.isOver(),
+        canDrop: !!monitor.canDrop(),
+        data: monitor.getItem(),
+      }),
+    }),
+    [onDrop],
+  );
+
+  const spacing = 12;
+
+  return (
+    <Box ref={drop}>
+      {(!isOver || !enableMoveInBetween) && (
+        <Box style={{ padding: 0, height: spacing, width: '100%' }} />
+      )}
+      {isOver && enableMoveInBetween && (
+        <Box
+          sx={{
+            opacity: 0.5,
+            paddingTop: spacing / 8,
+            paddingBottom: spacing / 8,
+          }}
+        >
+          {renderComponent(data, {
+            isOver: false,
+            isDragging: false,
+            isMovable: false,
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default InBetween;

--- a/src/draggable/types.ts
+++ b/src/draggable/types.ts
@@ -1,0 +1,11 @@
+export type DraggableAndDroppableProps = {
+  isDragging: boolean;
+  isOver: boolean;
+  isMovable: boolean;
+};
+
+export type DroppedFile = {
+  dataTransfer: DataTransfer;
+  files: File[];
+  items: DataTransferItemList;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,3 +90,7 @@ export * from './Tree/types';
 export * from './ThemeContext';
 
 export * from './types';
+
+export { default as DraggingWrapper } from './draggable/DraggingWrapper';
+export * from './draggable/types';
+export { default as TableToolbar } from './TableComponent/TableToolbar';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,7 +4402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/csf-tools@npm:8.1.10, @storybook/csf-tools@npm:^8.0.0":
+"@storybook/csf-tools@npm:8.1.10":
   version: 8.1.10
   resolution: "@storybook/csf-tools@npm:8.1.10"
   dependencies:
@@ -4419,7 +4419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/csf-tools@npm:8.1.11":
+"@storybook/csf-tools@npm:8.1.11, @storybook/csf-tools@npm:^8.0.0":
   version: 8.1.11
   resolution: "@storybook/csf-tools@npm:8.1.11"
   dependencies:
@@ -6024,10 +6024,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/shared@npm:3.4.30, @vue/shared@npm:^3.3.0":
+"@vue/shared@npm:3.4.30":
   version: 3.4.30
   resolution: "@vue/shared@npm:3.4.30"
   checksum: 10/82c55bd70b1b42c796606a998f9f96356c4eff0ced24f0bc64a8ed67e9cead3fda1ff543f429442b04868186da258c2e8cdbaed49d51a254ab99765b88d63947
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:^3.3.0":
+  version: 3.4.31
+  resolution: "@vue/shared@npm:3.4.31"
+  checksum: 10/ec11ba892b6f6f078fd620e5a2c16d57935f69e7a3dbae20c18e79c70e1bc89fa6d463d5fcbb220f54e9e4122dbc0bb04024059afecd6acf6b182d3c071e3c3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds `DraggingWrapper` to allow moving and dropping elements in other elements. I changed the cards for updated item table layout.