### PR TITLE
fix: allow container to take full-width

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@emotion/cache": "~11.11.0",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
-    "@graasp/sdk": "4.15.0",
+    "@graasp/sdk": "github:graasp/graasp-sdk#remove-ui-functions",
     "@mui/icons-material": "5.15.20",
     "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "5.15.20",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@emotion/cache": "~11.11.0",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
-    "@graasp/sdk": "github:graasp/graasp-sdk#remove-ui-functions",
+    "@graasp/sdk": "4.15.1",
     "@mui/icons-material": "5.15.20",
     "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "5.15.20",

--- a/src/items/FileAudio.tsx
+++ b/src/items/FileAudio.tsx
@@ -12,6 +12,7 @@ type FileAudioProps = {
 const FileAudio: FC<FileAudioProps> = ({ id, url, type, sx }) => {
   const StyledAudio = styled('audio')({
     maxWidth: '100%',
+    width: '100%',
   });
   return (
     <StyledAudio sx={sx} id={id} controls>

--- a/src/items/FileItem.stories.tsx
+++ b/src/items/FileItem.stories.tsx
@@ -10,20 +10,12 @@ import {
 } from '@graasp/sdk';
 
 import { MOCK_MEMBER } from '../utils/fixtures';
-import { TABLE_CATEGORIES } from '../utils/storybook';
 import FileItem from './FileItem';
 
 const meta = {
   title: 'Items/FileItem',
   component: FileItem,
 
-  argTypes: {
-    sx: {
-      table: {
-        category: TABLE_CATEGORIES.MUI,
-      },
-    },
-  },
   render: (args, { loaded: { content } }) => {
     return <FileItem {...args} content={content} />;
   },

--- a/src/items/FileItem.tsx
+++ b/src/items/FileItem.tsx
@@ -1,4 +1,4 @@
-import { Box, SxProps } from '@mui/material';
+import { Box } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Skeleton from '@mui/material/Skeleton';
 
@@ -7,7 +7,6 @@ import React, { useEffect, useState } from 'react';
 import {
   ItemType,
   LocalFileItemType,
-  MaxWidth,
   MimeTypes,
   S3FileItemType,
   getFileExtra,
@@ -23,7 +22,7 @@ import FileImage from './FileImage';
 import FilePdf from './FilePdf';
 import FileVideo from './FileVideo';
 import { SizingWrapper } from './SizingWrapper';
-import withCaption from './withCaption';
+import { CaptionWrapper } from './withCaption';
 
 export type FileItemProps = {
   /**
@@ -44,9 +43,7 @@ export type FileItemProps = {
    * use a custom pdf reader from the link if defined
    * */
   pdfViewerLink?: string;
-  showCaption?: boolean;
   showCollapse?: boolean;
-  sx?: SxProps;
   onClick?: () => void;
 };
 
@@ -59,9 +56,7 @@ const FileItem = ({
   id,
   item,
   maxHeight = '100%',
-  showCaption = true,
   showCollapse,
-  sx,
   pdfViewerLink,
   onClick,
 }: FileItemProps): JSX.Element => {
@@ -125,17 +120,16 @@ const FileItem = ({
           </Box>
         );
       } else if (MimeTypes.isAudio(mimetype)) {
-        return <FileAudio id={id} url={url} type={mimetype} sx={sx} />;
+        return <FileAudio id={id} url={url} type={mimetype} />;
       } else if (MimeTypes.isVideo(mimetype)) {
         // does not specify mimetype in video source, this way, it works with more container formats in more browsers (especially Chrome with video/quicktime)
-        return <FileVideo id={id} url={url} sx={sx} />;
+        return <FileVideo id={id} url={url} />;
       } else if (MimeTypes.isPdf(mimetype)) {
         return (
           <FilePdf
             id={id}
             url={url}
             height={maxHeight}
-            sx={sx}
             showCollapse={showCollapse}
             pdfViewerLink={pdfViewerLink}
           />
@@ -161,17 +155,11 @@ const FileItem = ({
   let fileItem = getComponent();
 
   fileItem = (
-    <SizingWrapper size={item.settings.maxWidth ?? MaxWidth.Medium}>
-      {fileItem}
-    </SizingWrapper>
+    <SizingWrapper size={item.settings.maxWidth}>{fileItem}</SizingWrapper>
   );
 
   // display element with caption
-  if (showCaption) {
-    fileItem = withCaption({
-      item,
-    })(fileItem);
-  }
+  fileItem = <CaptionWrapper item={item}>{fileItem}</CaptionWrapper>;
 
   if (showCollapse) {
     fileItem = withCollapse({ item })(fileItem);

--- a/src/items/SizingWrapper.tsx
+++ b/src/items/SizingWrapper.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 
 import { MaxWidth } from '@graasp/sdk';
 
-const getWidthFromSizing = (size: MaxWidth): string => {
+const getWidthFromSizing = (size?: MaxWidth): string => {
   switch (size) {
     case MaxWidth.ExtraSmall:
       return '100px';
@@ -14,6 +14,7 @@ const getWidthFromSizing = (size: MaxWidth): string => {
       return '400px';
     case MaxWidth.Large:
       return '800px';
+    // default is for the element to take all available horizontal space
     case MaxWidth.ExtraLarge:
     default:
       return '100%';
@@ -21,10 +22,10 @@ const getWidthFromSizing = (size: MaxWidth): string => {
 };
 
 export const SizingWrapper = ({
-  size,
+  size = MaxWidth.ExtraLarge,
   children,
 }: {
-  size: MaxWidth;
+  size?: MaxWidth;
   children: ReactNode;
 }): JSX.Element => {
   const width = getWidthFromSizing(size);

--- a/src/items/withCaption.tsx
+++ b/src/items/withCaption.tsx
@@ -7,13 +7,35 @@ import { ReactNode } from 'react';
 import {
   Alignment,
   AlignmentType,
-  DEFAULT_FILE_ALIGNMENT_SETTING,
   DescriptionPlacement,
   DescriptionPlacementType,
+  DiscriminatedItem,
+  MimeTypes,
+  getMimetype,
 } from '@graasp/sdk';
 
+export const getDefaultFileAlignmentSetting = (
+  mimetype?: string,
+): AlignmentType => {
+  if (!mimetype) {
+    return Alignment.Left;
+  }
+
+  switch (true) {
+    case MimeTypes.isImage(mimetype):
+    case MimeTypes.isAudio(mimetype):
+    case MimeTypes.isVideo(mimetype):
+    case MimeTypes.isPdf(mimetype):
+      return Alignment.Center;
+
+    // unknown mimetype gets
+    default:
+      return Alignment.Left;
+  }
+};
+
 const getAlignItemsFromAlignmentSetting = (
-  alignment: AlignmentType = DEFAULT_FILE_ALIGNMENT_SETTING,
+  alignment: AlignmentType,
 ): 'flex-start' | 'flex-end' | 'center' => {
   switch (alignment) {
     case Alignment.Right:
@@ -44,6 +66,7 @@ type WithCaptionItem = {
     descriptionPlacement?: DescriptionPlacementType;
     alignment?: AlignmentType;
   };
+  extra?: DiscriminatedItem['extra'];
 };
 
 type WithCaptionProps<T extends WithCaptionItem> = {
@@ -60,9 +83,13 @@ export const CaptionWrapper = <T extends WithCaptionItem>({
       ? 'column-reverse'
       : 'column';
 
-  const alignItems = getAlignItemsFromAlignmentSetting(
-    item.settings?.alignment,
-  );
+  const alignment =
+    item.settings?.alignment ??
+    getDefaultFileAlignmentSetting(
+      item.extra ? getMimetype(item.extra) : undefined,
+    );
+
+  const alignItems = getAlignItemsFromAlignmentSetting(alignment);
   const description = normalizeDescription(item.description);
 
   return (

--- a/src/items/withCaption.tsx
+++ b/src/items/withCaption.tsx
@@ -47,7 +47,12 @@ function withCaption<T extends WithCaptionItem>({ item }: WithCaptionProps<T>) {
       const alignItems = getAlignItemsFromAlignmentSetting(alignmentSetting);
       const description = normalizeDescription(item.description);
       return (
-        <Stack direction={direction} gap={0.5} alignItems={alignItems}>
+        <Stack
+          direction={direction}
+          gap={0.5}
+          alignItems={alignItems}
+          width='100%'
+        >
           {component}
           <TextDisplay content={description} />
         </Stack>

--- a/src/items/withCaption.tsx
+++ b/src/items/withCaption.tsx
@@ -2,12 +2,28 @@ import TextDisplay from '@/TextDisplay/TextDisplay';
 
 import { Stack } from '@mui/material';
 
+import { ReactNode } from 'react';
+
 import {
+  Alignment,
   AlignmentType,
+  DEFAULT_FILE_ALIGNMENT_SETTING,
   DescriptionPlacement,
   DescriptionPlacementType,
-  getAlignItemsFromAlignmentSetting,
 } from '@graasp/sdk';
+
+const getAlignItemsFromAlignmentSetting = (
+  alignment: AlignmentType = DEFAULT_FILE_ALIGNMENT_SETTING,
+): 'flex-start' | 'flex-end' | 'center' => {
+  switch (alignment) {
+    case Alignment.Right:
+      return 'flex-end';
+    case Alignment.Left:
+      return 'flex-start';
+    case Alignment.Center:
+      return 'center';
+  }
+};
 
 const normalizeDescription = (value: string | null | undefined): string => {
   // description may be null or undefined, we return empty string
@@ -34,32 +50,34 @@ type WithCaptionProps<T extends WithCaptionItem> = {
   item: T;
 };
 
-function withCaption<T extends WithCaptionItem>({ item }: WithCaptionProps<T>) {
-  return (component: JSX.Element): JSX.Element => {
-    const ChildComponent = (): JSX.Element => {
-      const descriptionPlacement =
-        item.settings?.descriptionPlacement ?? 'below';
-      const alignmentSetting = item.settings?.alignment;
-      const direction =
-        descriptionPlacement === DescriptionPlacement.ABOVE
-          ? 'column-reverse'
-          : 'column';
-      const alignItems = getAlignItemsFromAlignmentSetting(alignmentSetting);
-      const description = normalizeDescription(item.description);
-      return (
-        <Stack
-          direction={direction}
-          gap={0.5}
-          alignItems={alignItems}
-          width='100%'
-        >
-          {component}
-          <TextDisplay content={description} />
-        </Stack>
-      );
-    };
+export const CaptionWrapper = <T extends WithCaptionItem>({
+  item,
+  children,
+}: WithCaptionProps<T> & { children: ReactNode }): JSX.Element => {
+  const descriptionPlacement = item.settings?.descriptionPlacement ?? 'below';
+  const direction =
+    descriptionPlacement === DescriptionPlacement.ABOVE
+      ? 'column-reverse'
+      : 'column';
 
-    return <ChildComponent />;
+  const alignItems = getAlignItemsFromAlignmentSetting(
+    item.settings?.alignment,
+  );
+  const description = normalizeDescription(item.description);
+
+  return (
+    <Stack direction={direction} gap={0.5} alignItems={alignItems} width='100%'>
+      {children}
+      <TextDisplay content={description} />
+    </Stack>
+  );
+};
+
+export function withCaption<T extends WithCaptionItem>({
+  item,
+}: WithCaptionProps<T>) {
+  return (component: JSX.Element): JSX.Element => {
+    return <CaptionWrapper item={item}>{component}</CaptionWrapper>;
   };
 }
 

--- a/src/items/withCaption.tsx
+++ b/src/items/withCaption.tsx
@@ -28,7 +28,7 @@ export const getDefaultFileAlignmentSetting = (
     case MimeTypes.isPdf(mimetype):
       return Alignment.Center;
 
-    // unknown mimetype gets
+    // unknown mimetype is left aligned
     default:
       return Alignment.Left;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,9 +2361,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#remove-ui-functions":
-  version: 4.15.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=53d328b647f58644e6d77bdc02c3ac0b7fe748c3"
+"@graasp/sdk@npm:4.15.1":
+  version: 4.15.1
+  resolution: "@graasp/sdk@npm:4.15.1"
   dependencies:
     "@faker-js/faker": "npm:8.4.1"
     filesize: "npm:10.1.2"
@@ -2372,7 +2372,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3
     uuid: ^9 || ^10.0.0
-  checksum: 10/9f706a51514afb0b1bd9614707d04b20784feddc81c4309a689d1fc31bc3a58a08b1ebf6dab0aafae2fc5b61d055519e51142f7cb4183e6728193865eccfc9e7
+  checksum: 10/17722029c75b0d43d0cbcbef24f7947434980ad26792c2fbb14ac3dc5b1a4a7dfc791b3d273c7a03b0650dbad7074598ac2bc04d307ea43d5d66bacaf3bc6edd
   languageName: node
   linkType: hard
 
@@ -2388,7 +2388,7 @@ __metadata:
     "@emotion/cache": "npm:~11.11.0"
     "@emotion/react": "npm:11.11.4"
     "@emotion/styled": "npm:11.11.5"
-    "@graasp/sdk": "github:graasp/graasp-sdk#remove-ui-functions"
+    "@graasp/sdk": "npm:4.15.1"
     "@mui/icons-material": "npm:5.15.20"
     "@mui/lab": "npm:5.0.0-alpha.170"
     "@mui/material": "npm:5.15.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,9 +2361,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:4.15.0":
+"@graasp/sdk@github:graasp/graasp-sdk#remove-ui-functions":
   version: 4.15.0
-  resolution: "@graasp/sdk@npm:4.15.0"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=53d328b647f58644e6d77bdc02c3ac0b7fe748c3"
   dependencies:
     "@faker-js/faker": "npm:8.4.1"
     filesize: "npm:10.1.2"
@@ -2372,7 +2372,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3
     uuid: ^9 || ^10.0.0
-  checksum: 10/02bd822171627b980804d702ac772635ba7288e10da9f8e2cce47893b79c663c410c51e3152e527151449c20f902b08e518a0aac420e059b027e387fb0b6f9e4
+  checksum: 10/9f706a51514afb0b1bd9614707d04b20784feddc81c4309a689d1fc31bc3a58a08b1ebf6dab0aafae2fc5b61d055519e51142f7cb4183e6728193865eccfc9e7
   languageName: node
   linkType: hard
 
@@ -2388,7 +2388,7 @@ __metadata:
     "@emotion/cache": "npm:~11.11.0"
     "@emotion/react": "npm:11.11.4"
     "@emotion/styled": "npm:11.11.5"
-    "@graasp/sdk": "npm:4.15.0"
+    "@graasp/sdk": "github:graasp/graasp-sdk#remove-ui-functions"
     "@mui/icons-material": "npm:5.15.20"
     "@mui/lab": "npm:5.0.0-alpha.170"
     "@mui/material": "npm:5.15.20"


### PR DESCRIPTION
In this PR:
- drop `sx` prop from FileItem
- drop `showCaption` prop from FileItem
- make `audio` full-width
- default sizing to full-width
- default alignement to center for content that has a known mimetype, other mimetypes that display as button are left-aligned
- add alignment conversion function from SDK back here
- export a captionWrapper as a simple component, keep the possibility of usign it as an HOC
