### PR TITLE
fix: theme overrides so helper text is not on white background

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -119,7 +119,9 @@ export const createGraaspTheme = ({
       MuiTextField: {
         styleOverrides: {
           root: {
-            backgroundColor: 'white',
+            '& input': {
+              backgroundColor: 'white',
+            },
           },
         },
       },


### PR DESCRIPTION
In this PR, I update the theme overrides in order for the helper text of the Textfield to be on the transparent background instead of the ugly white. 
