### PR TITLE
fix: add buttonColor hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './items/index.js';
 
 export * from './hooks/useFullscreen.js';
 export * from './hooks/useMobileView.js';
+export * from './buttons/hooks.js';
 
 export * from './icons/index.js';
 export * from './buttons/index.js';


### PR DESCRIPTION
add missing export for `useButtonColor` hook