### PR TITLE
fix: reverse pin icon

### DIFF
--- a/src/buttons/PinButton/PinButton.tsx
+++ b/src/buttons/PinButton/PinButton.tsx
@@ -39,9 +39,9 @@ const PinButton = ({
 }: PinButtonProps): JSX.Element => {
   const { color: buttonColor } = useButtonColor(color);
   const icon = isPinned ? (
-    <Pin color={buttonColor} />
-  ) : (
     <PinOff color={buttonColor} />
+  ) : (
+    <Pin color={buttonColor} />
   );
   const text = isPinned ? unPinText : pinText;
 


### PR DESCRIPTION
The icon was not following the logic of the text.
The icon and the text are describing the next action.