### PR TITLE
fix: quill placeholder does not update

### DIFF
--- a/src/TextEditor/TextEditor.stories.tsx
+++ b/src/TextEditor/TextEditor.stories.tsx
@@ -18,7 +18,6 @@ const meta = {
   args: {
     onChange: fn(),
   },
-  render: (args) => <TextEditor {...args} />,
 } satisfies Meta<typeof TextEditor>;
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/TextEditor/TextEditor.tsx
+++ b/src/TextEditor/TextEditor.tsx
@@ -3,7 +3,7 @@ import katex from 'katex';
 
 import { Stack, styled } from '@mui/material';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ReactQuill from 'react-quill';
 
 import Button from '../buttons/Button/Button.js';
@@ -84,6 +84,7 @@ const TextEditor = ({
 }: TextEditorProps): JSX.Element | null => {
   // keep current content
   const [content, setContent] = useState(initialValue ?? '');
+  const editorRef = useRef<ReactQuill>(null);
 
   const onTextChange = (text: string): void => {
     // keep track of the current content
@@ -101,10 +102,19 @@ const TextEditor = ({
     setContent(initialValue);
   }, [initialValue]);
 
+  // this hack is necessary because the "placeholder" prop does not update
+  // see: https://github.com/zenoamaro/react-quill/issues/340
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.getEditor().root.dataset.placeholder = placeholderText;
+    }
+  }, [placeholderText]);
+
   return (
     <Stack direction='column' spacing={1} alignItems='flex-end'>
       <Div>
         <ReactQuill
+          ref={editorRef}
           id={id}
           placeholder={placeholderText}
           theme='snow'

--- a/src/TextEditor/TextEditorWrapper.stories.tsx
+++ b/src/TextEditor/TextEditorWrapper.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from '@storybook/test';
+
+import { useState } from 'react';
+
+import TextEditor, { TextEditorProps } from './TextEditor.js';
+
+const BUTTON_ID = 'button-id';
+const NEW_PLACEHOLDER_TEXT = 'new placeholder text';
+const TextEditorWrapper = (args: TextEditorProps): JSX.Element => {
+  const [placeholder, setPlaceholder] = useState(args.placeholderText);
+  return (
+    <>
+      <button
+        data-testid={BUTTON_ID}
+        onClick={() => setPlaceholder(NEW_PLACEHOLDER_TEXT)}
+      >
+        change text
+      </button>
+      <TextEditor {...args} placeholderText={placeholder} />
+    </>
+  );
+};
+
+const meta = {
+  title: 'Text/TextEditorWrapper',
+  component: TextEditorWrapper,
+  args: {
+    onChange: fn(),
+    id: 'editor-id',
+  },
+} satisfies Meta<typeof TextEditor>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Placeholder = {
+  args: {
+    placeholderText: 'Initial placeholder',
+    value: '',
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvasElement
+        .querySelector(`[id=${args.id}] .ql-editor`)
+        ?.getAttribute('data-placeholder'),
+    ).toEqual(args.placeholderText);
+    await userEvent.click(canvas.getByTestId(BUTTON_ID));
+    await expect(
+      canvasElement
+        .querySelector(`[id=${args.id}] .ql-editor`)
+        ?.getAttribute('data-placeholder'),
+    ).toEqual(NEW_PLACEHOLDER_TEXT);
+  },
+} satisfies Story;


### PR DESCRIPTION
This PR fixes a very sneaky bug with the unusual behaviour of the `placeholder` prop from react-quill.

I have added an interaction test that ensures that the placeholder can be updated.

fix #1049 