### PR TITLE
fix: pass classname to dense card

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -39,6 +39,10 @@ type CardProps = {
   name: string | JSX.Element;
   alt: string;
   id?: string;
+  /**
+   * Classname for the element.
+   * Useful for selecting many cards at the same time (eg. drag targets).
+   */
   className?: string;
   /**
    * creator name

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -206,7 +206,13 @@ const Card = ({
   }
 
   return (
-    <StyledCard isOver={isOver} id={id} sx={sx} fullWidth={fullWidth}>
+    <StyledCard
+      isOver={isOver}
+      id={id}
+      sx={sx}
+      fullWidth={fullWidth}
+      className={className}
+    >
       <Stack sx={{ height, boxSizing: 'border-box' }} direction='row' gap={2}>
         <CardThumbnail
           width={height}


### PR DESCRIPTION
ref https://github.com/graasp/graasp-builder/issues/1433

The solution is to keep track of cards, which is done through a class for dense cards, but not non-dense cards.