### PR TITLE
fix: footer should use footer html tag

### DIFF
--- a/src/Main/Main.tsx
+++ b/src/Main/Main.tsx
@@ -63,7 +63,7 @@ const StyledMain = styled('main', {
     ...(open && openDrawerStyles(theme)),
   }),
 );
-const StyledFooter = styled('main', {
+const StyledFooter = styled('footer', {
   shouldForwardProp: (prop) => prop !== 'open',
 })<{ open: boolean }>(({ theme, open }) => ({
   ...(open && openDrawerStyles(theme)),


### PR DESCRIPTION
This fixes a small bug where the footer of the `Main` component was using a `main` html tag instead of a `footer` tag.