### PR TITLE
fix: add useFullscreen hook in apps bundle

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -6,3 +6,4 @@ export {
   RequiredChip,
   type UserFeedback,
 } from './appComponents/index.js';
+export * from './hooks/useFullscreen.js';


### PR DESCRIPTION
In this PR I add the `useFullscreen` hook to the apps bundle so it can be used without errors if you do not have the required dependencies.